### PR TITLE
Added Pre Build Event to Kill CEF Process

### DIFF
--- a/Google Play Music/Google Play Music.csproj
+++ b/Google Play Music/Google Play Music.csproj
@@ -320,9 +320,6 @@
   </Target>
   <Import Project="..\packages\cef.redist.x86.3.2357.1287\build\cef.redist.x86.targets" Condition="Exists('..\packages\cef.redist.x86.3.2357.1287\build\cef.redist.x86.targets')" />
   <Import Project="..\packages\CefSharp.Common.43.0.0\build\CefSharp.Common.targets" Condition="Exists('..\packages\CefSharp.Common.43.0.0\build\CefSharp.Common.targets')" />
-  <PropertyGroup>
-    <PreBuildEvent>taskkill /F /IM CefSharp.BrowserSubprocess.exe 2&gt;&amp;1 | exit /B 0</PreBuildEvent>
-  </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Google Play Music/Google Play Music.csproj
+++ b/Google Play Music/Google Play Music.csproj
@@ -320,6 +320,9 @@
   </Target>
   <Import Project="..\packages\cef.redist.x86.3.2357.1287\build\cef.redist.x86.targets" Condition="Exists('..\packages\cef.redist.x86.3.2357.1287\build\cef.redist.x86.targets')" />
   <Import Project="..\packages\CefSharp.Common.43.0.0\build\CefSharp.Common.targets" Condition="Exists('..\packages\CefSharp.Common.43.0.0\build\CefSharp.Common.targets')" />
+  <PropertyGroup>
+    <PreBuildEvent>taskkill /F /IM CefSharp.BrowserSubprocess.exe 2&gt;&amp;1 | exit /B 0</PreBuildEvent>
+  </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Google Play Music/JSBound.cs
+++ b/Google Play Music/JSBound.cs
@@ -95,13 +95,10 @@ namespace Google_Play_Music
         // Fired from javascript when a different song has been playing for over half it's duration. (As according to last.fm's scrobbling spec)
         public void songScrobbleRequest(string song, string artist, string album, int timestamp)
         {
-            try
+            // Check last.fm user authenticated before attempting to "scrobble" the current song.
+            if (LastFM.user_key != null)
             {
                 new LastFM().scrobbleTrack(artist, song, timestamp).Wait();
-            }
-            catch (Exception e)
-            {
-                // last.fm not authenticated
             }
         }
 
@@ -147,12 +144,11 @@ namespace Google_Play_Music
                 // The AsyncJSBind in CEFSharp can't handle the amount of communication and throws a NullPointer
                 // TODO: Check CEF progress on this issue
             }
-            try
+
+            // Check last.fm user authenticated before attempting to update the current song.
+            if (LastFM.user_key != null)
             {
                 new LastFM().updateNowPlaying(artist, song).Wait();
-            } catch (Exception e)
-            {
-                // last.fm not authenticated
             }
         }
 

--- a/Google Play Music/JSBound.cs
+++ b/Google Play Music/JSBound.cs
@@ -95,10 +95,13 @@ namespace Google_Play_Music
         // Fired from javascript when a different song has been playing for over half it's duration. (As according to last.fm's scrobbling spec)
         public void songScrobbleRequest(string song, string artist, string album, int timestamp)
         {
-            // Check last.fm user authenticated before attempting to "scrobble" the current song.
-            if (LastFM.user_key != null)
+            try
             {
                 new LastFM().scrobbleTrack(artist, song, timestamp).Wait();
+            }
+            catch (Exception e)
+            {
+                // last.fm not authenticated
             }
         }
 
@@ -144,11 +147,12 @@ namespace Google_Play_Music
                 // The AsyncJSBind in CEFSharp can't handle the amount of communication and throws a NullPointer
                 // TODO: Check CEF progress on this issue
             }
-
-            // Check last.fm user authenticated before attempting to update the current song.
-            if (LastFM.user_key != null)
+            try
             {
                 new LastFM().updateNowPlaying(artist, song).Wait();
+            } catch (Exception e)
+            {
+                // last.fm not authenticated
             }
         }
 


### PR DESCRIPTION
Added a pre-build event to kill the CefSharp.BrowserSubprocess that will lock the assemblies when debugging is stopped unexpectedly.