### PR TITLE
Added Pre Build Event to Kill CEF Process 

### DIFF
--- a/Google Play Music/Google Play Music.csproj
+++ b/Google Play Music/Google Play Music.csproj
@@ -320,6 +320,9 @@
   </Target>
   <Import Project="..\packages\cef.redist.x86.3.2357.1287\build\cef.redist.x86.targets" Condition="Exists('..\packages\cef.redist.x86.3.2357.1287\build\cef.redist.x86.targets')" />
   <Import Project="..\packages\CefSharp.Common.43.0.0\build\CefSharp.Common.targets" Condition="Exists('..\packages\CefSharp.Common.43.0.0\build\CefSharp.Common.targets')" />
+  <PropertyGroup>
+    <PreBuildEvent>taskkill /F /IM CefSharp.BrowserSubprocess.exe 2&gt;&amp;1 | exit /B 0</PreBuildEvent>
+  </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">


### PR DESCRIPTION
Added a pre-build event to kill the CefSharp.BrowserSubprocess that will lock the assemblies when debugging is stopped unexpectedly.