### PR TITLE
Bind CTRL-F to jump to the find input box

### DIFF
--- a/Google Play Music/CoreMusicApp.Hooks.cs
+++ b/Google Play Music/CoreMusicApp.Hooks.cs
@@ -23,7 +23,6 @@ namespace Google_Play_Music
                         break;
                 }
             };
-            globalKeyMouseHook.KeyDown += new KeyEventHandler(gkh_KeyDown);
             globalKeyMouseHook.KeyUp += new KeyEventHandler(gkh_KeyUp);
             FormClosed += (send, e) =>
             {
@@ -31,13 +30,13 @@ namespace Google_Play_Music
             };
         }
 
-        private bool controlDown = false;
         // Due to the syncronous (and slow) nature of the SetZoomLevel method on a CefBrowser object
         // We wait until the previous zoom is finished before allowing a new zoom to be requested
         private bool zoomInProgress = false;
 
         void gkh_KeyUp(object sender, KeyEventArgs e)
         {
+            bool controlDown = (ModifierKeys & Keys.Control) == Keys.Control;
             switch (e.KeyCode)
             {
                 case Keys.MediaPlayPause:
@@ -57,7 +56,6 @@ namespace Google_Play_Music
                 case Keys.ControlKey:
                 case Keys.RControlKey:
                 case Keys.LControlKey:
-                    controlDown = false;
                     break;
                 case Keys.Oemplus:
                 case Keys.Add:
@@ -88,16 +86,12 @@ namespace Google_Play_Music
                         zoomInProgress = false;
                     }
                     break;
-
-            }
-            e.Handled = false;
-        }
-
-        void gkh_KeyDown(object sender, KeyEventArgs e)
-        {
-            if (new List<Keys> { Keys.Control, Keys.ControlKey, Keys.RControlKey, Keys.LControlKey }.Contains(e.KeyCode))
-            {
-                controlDown = true;
+                case Keys.F:
+                    if(controlDown && ApplicationIsActivated())
+                    {
+                        this.findFocus();
+                    }
+                    break;
             }
             e.Handled = false;
         }

--- a/Google Play Music/CoreMusicApp.cs
+++ b/Google Play Music/CoreMusicApp.cs
@@ -176,6 +176,11 @@ namespace Google_Play_Music
             GPMBrowser.EvaluateScriptAsync("(function() {document.querySelectorAll('[data-id=forward]')[0].click()})()");
         }
 
+        private void findFocus()
+        {
+            GPMBrowser.EvaluateScriptAsync("(function() {document.querySelectorAll('sj-search-box > input')[0].focus()})()");
+        }
+
         // Task Bar Media Controls
         private ThumbnailToolBarButton prevTrackButton;
         private ThumbnailToolBarButton nextTrackButton;


### PR DESCRIPTION
This commit binds the Ctrl-F (commonly used find shortcut) to focus the find input box, allowing users to press Ctrl-F and begin searching. As per feature request on issue #93 