### PR TITLE
LastFM Integration Overhaul

### DIFF
--- a/Google Play Music/App.config
+++ b/Google Play Music/App.config
@@ -4,10 +4,35 @@
         <sectionGroup name="userSettings" type="System.Configuration.UserSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
             <section name="Google_Play_Music.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" allowExeDefinition="MachineToLocalUser" requirePermission="false" />
         </sectionGroup>
+        <section name="log4net" type="log4net.Config.Log4NetConfigurationSectionHandler, log4net"/>
     </configSections>
-    <startup> 
-        
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.0" /></startup>
+    <log4net>
+        <root>
+            <level value="ALL" />
+            <appender-ref ref="DebugAppender" />
+            <appender-ref ref="RollingFileAppender" />
+        </root>
+        <appender name="DebugAppender" type="log4net.Appender.DebugAppender">
+            <immediateFlush value="true"/>
+            <layout type="log4net.Layout.PatternLayout">
+                <conversionPattern value="%-24date [%3.3thread] %-5level - %message%newline%exception"/>
+            </layout>
+        </appender>
+        <appender name="RollingFileAppender" type="log4net.Appender.RollingFileAppender">
+            <file value="google_play_music.log" />
+            <appendToFile value="true" />
+            <rollingStyle value="Size" />
+            <maxSizeRollBackups value="5" />
+            <maximumFileSize value="10MB" />
+            <staticLogFileName value="true" />
+            <layout type="log4net.Layout.PatternLayout">
+                <conversionPattern value="%-24date [%3.3thread] %-5level - %message%newline%exception"/>
+            </layout>
+        </appender>
+    </log4net>
+    <startup>
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.0" />
+    </startup>
     <userSettings>
         <Google_Play_Music.Properties.Settings>
             <setting name="MaxiSize" serializeAs="String">
@@ -48,20 +73,20 @@
             </setting>
         </Google_Play_Music.Properties.Settings>
     </userSettings>
-  <runtime>
-    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-      <dependentAssembly>
-        <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.6.10.0" newVersion="2.6.10.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Threading.Tasks" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.6.10.0" newVersion="2.6.10.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Net.Http" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.2.29.0" newVersion="2.2.29.0" />
-      </dependentAssembly>
-    </assemblyBinding>
-  </runtime>
+    <runtime>
+        <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+            <dependentAssembly>
+                <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+                <bindingRedirect oldVersion="0.0.0.0-2.6.10.0" newVersion="2.6.10.0" />
+            </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="System.Threading.Tasks" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+                <bindingRedirect oldVersion="0.0.0.0-2.6.10.0" newVersion="2.6.10.0" />
+            </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="System.Net.Http" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+                <bindingRedirect oldVersion="0.0.0.0-2.2.29.0" newVersion="2.2.29.0" />
+            </dependentAssembly>
+        </assemblyBinding>
+    </runtime>
 </configuration>

--- a/Google Play Music/CoreMusicApp.cs
+++ b/Google Play Music/CoreMusicApp.cs
@@ -55,7 +55,8 @@ namespace Google_Play_Music
                 if (mini)
                 {
                     saveMiniState();
-                } else
+                }
+                else
                 {
                     if (WindowState != FormWindowState.Normal)
                     {
@@ -71,7 +72,7 @@ namespace Google_Play_Music
             };
 
             // Check for updates on the Github Release API
-            checkForUpdates();
+            CheckForUpdates();
             RegisterKeyHooks();
         }
 
@@ -125,13 +126,14 @@ namespace Google_Play_Music
             {
                 MaximizeWindow(true);
                 return;
-            } else if (m.Msg == NativeMethods.WM_SHOWME)
+            }
+            else if (m.Msg == NativeMethods.WM_SHOWME)
             {
                 if (WindowState == FormWindowState.Minimized)
                 {
                     WindowState = FormWindowState.Normal;
                 }
-                
+
                 bool top = TopMost;
                 TopMost = true;
                 TopMost = top;

--- a/Google Play Music/Google Play Music.csproj
+++ b/Google Play Music/Google Play Music.csproj
@@ -115,6 +115,10 @@
       <HintPath>..\packages\MouseKeyHook.5.3.0\lib\net40\Gma.System.MouseKeyHook.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="log4net, Version=1.2.15.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
+      <HintPath>..\packages\log4net.2.0.5\lib\net40-full\log4net.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Microsoft.Threading.Tasks, Version=1.0.12.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.dll</HintPath>
       <Private>True</Private>
@@ -173,7 +177,6 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Web" />
-    <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/Google Play Music/LastFM.Intergration.cs
+++ b/Google Play Music/LastFM.Intergration.cs
@@ -11,97 +11,116 @@ using System.Text;
 
 namespace Google_Play_Music
 {
-    class LastFM
+    internal class LastFM
     {
-        private string username;
-        private string password;
-        public static string user_key = null;
+        private string user_key = null;
+        private static LastFM instance;
 
         private const string API_KEY = "";
         private const string API_SECRET = "";
         private const string API_URL = "https://ws.audioscrobbler.com/2.0/?";
 
-        public LastFM()
-        {
-            this.username = Properties.Settings.Default.LastFMUsername;
-            this.password = Properties.Settings.Default.LastFMPassword;
-        }
+        public string UserName { get; set; }
+        public string Password { get; set; }
 
-        public LastFM(string username, string password)
+        public static LastFM GetInstance()
         {
-            this.username = username;
-            this.password = password;
-        }
-
-        public async Task init()
-        {
-            await attemptLogIn();
-        }
-
-        public async Task attemptLogIn()
-        {
-            if (username == "Username" || password == "1234567")
+            if (instance == null)
             {
-                return;
+                instance = new LastFM();
+                instance.UserName = Properties.Settings.Default.LastFMUsername;
+                instance.Password = Properties.Settings.Default.LastFMPassword;
             }
-            Dictionary<String, String> attrs = new Dictionary<string, string>();
-            attrs["password"] = password;
-            attrs["username"] = username;
-            string requestURL = generateAPIRequestURL("auth.getMobileSession", attrs);
 
-            string auth_response = await fetchURL(requestURL);
-            
+            return instance;
+        }
+
+        public async Task<Boolean> AttemptLogIn()
+        {
+            return await AttemptLogIn(UserName, Password);
+        }
+
+        public async Task<Boolean> AttemptLogIn(string userName, string password)
+        {
+            if (userName == "Username" && password == "1234567")
+            {
+                Program.Logger.Info("Skipped logging with default credentials (Username or 1234567)");
+                return false;
+            }
+
+            Dictionary<String, String> attrs = new Dictionary<string, string>();
+
+            attrs["password"] = password;
+            attrs["username"] = userName;
+
+            string requestURL = GenerateAPIRequestURL("auth.getMobileSession", attrs);
+
+            Program.Logger.InfoFormat("Attempting login for '{0}'", userName);
+
+            string auth_response = await FetchURL(requestURL);
+
             if (auth_response == "")
             {
+                Program.Logger.InfoFormat("Failed login for '{0}'", userName);
                 user_key = null;
-                return;
+                return false;
             }
 
-            AuthenticationResponse auth = new System.Web.Script.Serialization.JavaScriptSerializer().Deserialize<AuthenticationResponse>(auth_response);
-            user_key = auth.session.key;
-            return;
+            Program.Logger.InfoFormat("Successful login for '{0}'", userName);
+
+            AuthenticationResponse auth = new System.Runtime.Serialization.Json.DataContractJsonSerializer(typeof(AuthenticationResponse)).ReadObject(new System.IO.MemoryStream(System.Text.Encoding.Unicode.GetBytes(auth_response))) as AuthenticationResponse;
+            user_key = auth.Session.Key;
+
+            Properties.Settings.Default.LastFMUsername = userName;
+            Properties.Settings.Default.LastFMPassword = password;
+
+            return true;
         }
 
-        private async Task<string> fetchURL(string URL)
+        private async Task<string> FetchURL(string URL)
         {
             using (var client = new HttpClient())
             {
+
                 Dictionary<string, string> values = new Dictionary<string, string>();
                 FormUrlEncodedContent content = new FormUrlEncodedContent(values);
+                string responseString = string.Empty;
 
                 try
                 {
+
                     HttpResponseMessage response = await client.PostAsync(URL, content);
-                    if (response.StatusCode != HttpStatusCode.OK)
+
+                    if (response.StatusCode == HttpStatusCode.OK)
                     {
-                        return "";
+                        responseString = await response.Content.ReadAsStringAsync();
                     }
-
-                    string responseString = await response.Content.ReadAsStringAsync();
-
-                    return responseString;
                 }
                 catch (Exception e)
                 {
-                    return "";
+                    // Todo: Move private information out of the query string before referencing the URL in the log since it will contain username, password, api_key, and the api_sig
+                    // Todo: Scrub the exception message before passing into the log because the message may contain the URL
+                    Program.Logger.Error("Error attempting to fetch url");
                 }
+
+                return responseString;
             }
         }
 
-        private string generateAPIRequestURL(string method, Dictionary<string, string> attributes)
+        private string GenerateAPIRequestURL(string method, Dictionary<string, string> attributes)
         {
-            string api_sig = signMethod(method, attributes);
-            string api_params = generateMethodParams(attributes);
+            string api_sig = SignMethod(method, attributes);
+            string api_params = GenerateMethodParams(attributes);
             string requestURL = API_URL + "method=" + method;
             requestURL += api_params;
-            requestURL += "&api_key=" + API_KEY + 
-                "&api_sig=" + api_sig +
-                "&format=json";
+            requestURL += "&api_key=" + API_KEY +
+                            "&api_sig=" + api_sig +
+                            "&format=json";
 
             return requestURL;
         }
 
-        private string generateMethodParams(Dictionary<string, string> attributes)
+        private string GenerateMethodParams(Dictionary<string, string> attributes)
         {
             string methodParams = "";
             List<string> keys = new List<string>(attributes.Keys);
@@ -113,7 +132,7 @@ namespace Google_Play_Music
             return methodParams;
         }
 
-        private string signMethod(string method, Dictionary<string, string> attributes)
+        private string SignMethod(string method, Dictionary<string, string> attributes)
         {
             string stringToSign = "";
             attributes["api_key"] = API_KEY;
@@ -130,52 +149,74 @@ namespace Google_Play_Music
         }
 
         // Here begins the API wrappers
-        public async Task updateNowPlaying(string artist, string track)
+        public async Task UpdateNowPlaying(string artist, string track, string album)
         {
             if (user_key == null)
             {
                 throw new Exception("The last.fm user is not authorized");
             }
+
             Dictionary<string, string> attributes = new Dictionary<string, string>();
             attributes["artist"] = artist;
             attributes["track"] = track;
+            attributes["album"] = album;
             attributes["sk"] = user_key;
 
-            string requestURL = generateAPIRequestURL("track.updateNowPlaying", attributes);
+            Program.Logger.InfoFormat("Updating now playing to artist:'{0}' track:'{1}' and album:'{2}'", artist, track, album);
 
-            await fetchURL(requestURL);
+            string requestURL = GenerateAPIRequestURL("track.updateNowPlaying", attributes);
+
+            await FetchURL(requestURL);
         }
 
-        public async Task scrobbleTrack(string artist, string track, int timestamp)
+        public async Task ScrobbleTrack(string artist, string track, string album, int timestamp)
         {
             if (user_key == null)
             {
                 throw new Exception("The last.fm user is not authorized");
             }
+
             Dictionary<string, string> attributes = new Dictionary<string, string>();
             attributes["artist"] = artist;
             attributes["track"] = track;
+            attributes["album"] = album;
             attributes["timestamp"] = timestamp.ToString();
             attributes["sk"] = user_key;
 
-            string requestURL = generateAPIRequestURL("track.scrobble", attributes);
+            Program.Logger.InfoFormat("Scrobbling artist:'{0}' track:'{1}', album:'{2}', timestamp:'{3}'", artist, track, album, timestamp);
 
-            await fetchURL(requestURL);
+            string requestURL = GenerateAPIRequestURL("track.scrobble", attributes);
+
+            await FetchURL(requestURL);
+        }
+
+        /// <summary>
+        /// Get a value indicating if the current user is authenticated with LastFM
+        /// </summary>
+        public bool IsAuthenticated()
+        {
+            return !string.IsNullOrEmpty(user_key);
         }
     }
 }
 
 namespace LastFMAPI
 {
+    [System.Runtime.Serialization.DataContract]
     public class AuthenticationResponse
     {
-        public AuthenticationSession session { get; set; }
+        [System.Runtime.Serialization.DataMember(Name = "session")]
+        public AuthenticationSession Session { get; set; }
     }
 
+    [System.Runtime.Serialization.DataContract]
     public class AuthenticationSession
     {
-        public int subscriber { get; set; }
-        public string name { get; set; }
-        public string key { get; set; }
+        [System.Runtime.Serialization.DataMember(Name = "subscriber")]
+        public int Subscriber { get; set; }
+        [System.Runtime.Serialization.DataMember(Name = "name")]
+        public string Name { get; set; }
+        [System.Runtime.Serialization.DataMember(Name = "key")]
+        public string Key { get; set; }
     }
 }

--- a/Google Play Music/LastFM.Intergration.cs
+++ b/Google Play Music/LastFM.Intergration.cs
@@ -37,12 +37,7 @@ namespace Google_Play_Music
 
         public async Task<Boolean> AttemptLogIn()
         {
-            return await AttemptLogIn(UserName, Password);
-        }
-
-        public async Task<Boolean> AttemptLogIn(string userName, string password)
-        {
-            if (userName == "Username" && password == "1234567")
+            if (UserName == "Username" && Password == "1234567")
             {
                 Program.Logger.Info("Skipped logging with default credentials (Username or 1234567)");
                 return false;
@@ -50,29 +45,29 @@ namespace Google_Play_Music
 
             Dictionary<String, String> attrs = new Dictionary<string, string>();
 
-            attrs["password"] = password;
-            attrs["username"] = userName;
+            attrs["password"] = Password;
+            attrs["username"] = UserName;
 
             string requestURL = GenerateAPIRequestURL("auth.getMobileSession", attrs);
 
-            Program.Logger.InfoFormat("Attempting login for '{0}'", userName);
+            Program.Logger.InfoFormat("Attempting login for '{0}'", UserName);
 
             string auth_response = await FetchURL(requestURL);
 
             if (auth_response == "")
             {
-                Program.Logger.InfoFormat("Failed login for '{0}'", userName);
+                Program.Logger.InfoFormat("Failed login for '{0}'", UserName);
                 user_key = null;
                 return false;
             }
 
-            Program.Logger.InfoFormat("Successful login for '{0}'", userName);
+            Program.Logger.InfoFormat("Successful login for '{0}'", UserName);
 
             AuthenticationResponse auth = new System.Runtime.Serialization.Json.DataContractJsonSerializer(typeof(AuthenticationResponse)).ReadObject(new System.IO.MemoryStream(System.Text.Encoding.Unicode.GetBytes(auth_response))) as AuthenticationResponse;
             user_key = auth.Session.Key;
 
-            Properties.Settings.Default.LastFMUsername = userName;
-            Properties.Settings.Default.LastFMPassword = password;
+            Properties.Settings.Default.LastFMUsername = UserName;
+            Properties.Settings.Default.LastFMPassword = Password;
 
             return true;
         }

--- a/Google Play Music/Program.cs
+++ b/Google Play Music/Program.cs
@@ -3,12 +3,14 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Forms;
+using log4net;
 
 namespace Google_Play_Music
 {
     static class Program
     {
         static Mutex mutex = new Mutex(true, "{8F6F0AC4-B9A1-45fd-A8CF-72F04E6BDE8F}");
+        internal static readonly ILog Logger = LogManager.GetLogger(typeof(Program));
 
         /// <summary>
         /// The main entry point for the application.
@@ -19,7 +21,7 @@ namespace Google_Play_Music
             if (mutex.WaitOne(TimeSpan.Zero, true))
             {
                 // Init the last.fm authentication with the user set username and password
-                Task lastFMInit = new LastFM().init();
+                Task lastFMInit = LastFM.GetInstance().AttemptLogIn();
                 lastFMInit.Wait();
 
                 Application.EnableVisualStyles();

--- a/Google Play Music/Properties/AssemblyInfo.cs
+++ b/Google Play Music/Properties/AssemblyInfo.cs
@@ -34,3 +34,4 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: log4net.Config.XmlConfigurator]

--- a/Google Play Music/SettingsDialog.cs
+++ b/Google Play Music/SettingsDialog.cs
@@ -29,6 +29,7 @@ namespace Google_Play_Music
             colorWheel1.Lightness = set.L;
 
             materialCheckBox1.Checked = Properties.Settings.Default.CustomTheme;
+
             materialCheckBox1.CheckStateChanged += (res, send) =>
             {
                 string command;
@@ -39,7 +40,8 @@ namespace Google_Play_Music
                     {
                         app.darkTheme();
                     });
-                } else
+                }
+                else
                 {
                     command = "window.turnOffCustom()";
                     app.Invoke((MethodInvoker)delegate
@@ -54,12 +56,14 @@ namespace Google_Play_Music
             };
 
             materialCheckBox2.Checked = Properties.Settings.Default.DesktopNotifications;
+
             materialCheckBox2.CheckStateChanged += (res, send) =>
             {
                 if (materialCheckBox2.Checked)
                 {
                     Properties.Settings.Default.DesktopNotifications = true;
-                } else
+                }
+                else
                 {
                     Properties.Settings.Default.DesktopNotifications = false;
                 }
@@ -91,18 +95,21 @@ namespace Google_Play_Music
             };
 
             lastFMUsername.Text = Properties.Settings.Default.LastFMUsername;
+
             lastFMUsername.GotFocus += (res, send) =>
             {
                 focusDefaultInputField(lastFMUsername, "Username", true);
             };
+
             lastFMUsername.LostFocus += async (res, send) =>
             {
                 focusDefaultInputField(lastFMUsername, "Username", false);
-                Properties.Settings.Default.LastFMUsername = lastFMUsername.Text;
-                lastFMAuth(-1);
-                await new LastFM().init();
-                lastFMAuth((LastFM.user_key != null ? 1 : 0));
+                LastFM.GetInstance().UserName = lastFMUsername.Text;
+                lastFmAuth(-1);
+                await LastFM.GetInstance().AttemptLogIn();
+                lastFmAuth((LastFM.GetInstance().IsAuthenticated() ? 1 : 0));
             };
+
             lastFMUsername.KeyPress += (send, e) =>
             {
                 if (e.KeyChar == (char)13)
@@ -119,11 +126,12 @@ namespace Google_Play_Music
             lastFMPassword.LostFocus += async (res, send) =>
             {
                 focusDefaultInputField(lastFMPassword, "1234567", false);
-                Properties.Settings.Default.LastFMPassword = lastFMPassword.Text;
-                lastFMAuth(-1);
-                await new LastFM().init();
-                lastFMAuth((LastFM.user_key != null ? 1 : 0));
+                LastFM.GetInstance().Password = lastFMPassword.Text;
+                lastFmAuth(-1);
+                await LastFM.GetInstance().AttemptLogIn();
+                lastFmAuth((LastFM.GetInstance().IsAuthenticated() ? 1 : 0));
             };
+
             lastFMPassword.KeyPress += (send, e) =>
             {
                 if (e.KeyChar == (char)13)
@@ -138,7 +146,8 @@ namespace Google_Play_Music
             if (field.Text == defaultText && focus)
             {
                 field.Text = "";
-            } else if (field.Text == "" && !focus)
+            }
+            else if (field.Text == "" && !focus)
             {
                 field.Text = defaultText;
             }
@@ -159,14 +168,15 @@ namespace Google_Play_Music
         {
             Activated += (res, send) =>
             {
-                lastFMAuth((LastFM.user_key != null ? 1 : 0));
+                lastFmAuth((LastFM.GetInstance().IsAuthenticated() ? 1 : 0));
                 Location = new Point(X - 300, Y - 200);
             };
+
             var result = ShowDialog();
             return result;
         }
 
-        private void lastFMAuth(int isAuth)
+        private void lastFmAuth(int isAuth)
         {
             // 1 = Auth Success
             // 0 = Auth Failure
@@ -175,11 +185,13 @@ namespace Google_Play_Music
             {
                 lastFMAuthIndicator.ForeColor = Color.Green;
                 lastFMAuthIndicator.Text = "Login Successful";
-            } else if (isAuth == 0)
+            }
+            else if (isAuth == 0)
             {
                 lastFMAuthIndicator.ForeColor = Color.Red;
                 lastFMAuthIndicator.Text = "Login Failed";
-            } else if (isAuth == -1)
+            }
+            else if (isAuth == -1)
             {
                 lastFMAuthIndicator.ForeColor = Color.Yellow;
                 lastFMAuthIndicator.Text = "Logging in...";

--- a/Google Play Music/packages.config
+++ b/Google Play Music/packages.config
@@ -4,6 +4,7 @@
   <package id="cef.redist.x86" version="3.2357.1287" targetFramework="net4" />
   <package id="CefSharp.Common" version="43.0.0" targetFramework="net4" />
   <package id="CefSharp.WinForms" version="43.0.0" targetFramework="net4" />
+  <package id="log4net" version="2.0.5" targetFramework="net40" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net4" />
   <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net4" />
   <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="net4" />


### PR DESCRIPTION
Added Log4Net for logging of LastFM log in attempts (only user name), errors, now playing, and scrobbles.
Reworked the LastFM integration to be a singleton to allow checking the user information before attempting to update or scrobble.
Replaced the System.Web Javascript JSON Deserializers with System.Runtime DataContractDeserializer. Can't remove the System.Web reference until migrating to .Net 4.5+ to use https://msdn.microsoft.com/en-us/library/system.net.webutility.urlencode(v=vs.110).aspx instead of HttpUtility.UrlEncode (LastFM.Integration/GenerateMethodParams).
Added album to the scrobble and song changed to correctly update widgets (in most cases).

**Note:** This overhaul continues to use the mobile style API rather than desktop style

*FYI*: Changing a password within the website will not cause errors with the updates as long as the previous authenticated user_key is used. 