### PR TITLE
Store Playback Information in File

### DIFF
--- a/Google Play Music/App.config
+++ b/Google Play Music/App.config
@@ -49,6 +49,12 @@
             <setting name="BetaStream" serializeAs="String">
                 <value>False</value>
             </setting>
+            <setting name="PublishPlaybackInformation" serializeAs="String">
+                <value>False</value>
+            </setting>
+            <setting name="PublishPlaybackInformationPath" serializeAs="String">
+                <value>%USERPROFILE%\gpm-status.json</value>
+            </setting>
         </Google_Play_Music.Properties.Settings>
     </userSettings>
   <runtime>

--- a/Google Play Music/CoreMusicApp.cs
+++ b/Google Play Music/CoreMusicApp.cs
@@ -57,6 +57,13 @@ namespace Google_Play_Music
             // Setup the Web Browser
             InitializeCEF();
 
+            FormClosing += (send, ev) =>
+            {
+                // Update PlayStatus when the app gets closed.
+                PlayStatus.Instance.information.isPlaying = false;
+                PlayStatus.Instance.Update();
+            };
+
             // Don't forget to save all our settings
             FormClosed += (send, ev) =>
             {

--- a/Google Play Music/Google Play Music.csproj
+++ b/Google Play Music/Google Play Music.csproj
@@ -229,6 +229,7 @@
     <Compile Include="CEF Modules\ResourceHandlerFactory.cs" />
     <Compile Include="CEF Modules\MenuHandler.cs" />
     <Compile Include="JSBound.cs" />
+    <Compile Include="PlayStatus.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Properties\Resources.Designer.cs">

--- a/Google Play Music/JSBound.cs
+++ b/Google Play Music/JSBound.cs
@@ -93,6 +93,12 @@ namespace Google_Play_Music
             });
         }
 
+        public void setPlaybackStatus(bool isPlaying)
+        {
+            PlayStatus.Instance.information.isPlaying = isPlaying;
+            PlayStatus.Instance.Update();
+        }
+
         public void setThumbbarToPlay()
         {
             mainForm.Invoke((MethodInvoker)delegate
@@ -135,6 +141,12 @@ namespace Google_Play_Music
         // Fired from javascript when a different song starts playing
         public void songChangeEvent(string song, string album, string artist, string url)
         {
+            PlayStatus.Instance.information.song = song;
+            PlayStatus.Instance.information.artist = artist;
+            PlayStatus.Instance.information.album = album;
+            PlayStatus.Instance.information.imageURL = url;
+            PlayStatus.Instance.Update();
+
             mainForm.Invoke((MethodInvoker)delegate
             {
                 // Update the title to show the current song

--- a/Google Play Music/PlayStatus.cs
+++ b/Google Play Music/PlayStatus.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.IO;
+using System.Web.Script.Serialization;
+
+namespace Google_Play_Music
+{
+    class PlayStatus
+    {
+        private bool publish;
+        private string filename;
+
+        public PlaybackInformation information = new PlaybackInformation();
+
+        internal class PlaybackInformation
+        {
+            public bool isPlaying = false;
+            public string song = "";
+            public string artist = "";
+            public string album = "";
+            public string imageURL = "";
+        }
+
+
+        PlayStatus()
+        {
+            this.UpdateSettings();
+        }
+
+
+
+        private string getStatusString()
+        {
+            return new JavaScriptSerializer().Serialize(information);
+        }
+
+        public void UpdateSettings()
+        {
+            this.publish = Properties.Settings.Default.PublishPlaybackInformation;
+            this.filename = Properties.Settings.Default.PublishPlaybackInformationPath;
+        }
+
+        public void Update()
+        {
+            if (this.publish)
+            {
+                System.IO.File.WriteAllText(Environment.ExpandEnvironmentVariables(this.filename), getStatusString());
+            }
+        }
+
+
+
+        private static PlayStatus instance;
+
+        public static PlayStatus Instance
+        {
+            get
+            {
+                if (instance == null)
+                {
+                    instance = new PlayStatus();
+                }
+                return instance;
+            }
+        }
+
+    }
+}

--- a/Google Play Music/Properties/Settings.Designer.cs
+++ b/Google Play Music/Properties/Settings.Designer.cs
@@ -178,5 +178,29 @@ namespace Google_Play_Music.Properties {
                 this["BetaStream"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool PublishPlaybackInformation {
+            get {
+                return ((bool)(this["PublishPlaybackInformation"]));
+            }
+            set {
+                this["PublishPlaybackInformation"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("%USERPROFILE%\\gpm-status.json")]
+        public string PublishPlaybackInformationPath {
+            get {
+                return ((string)(this["PublishPlaybackInformationPath"]));
+            }
+            set {
+                this["PublishPlaybackInformationPath"] = value;
+            }
+        }
     }
 }

--- a/Google Play Music/Properties/Settings.settings
+++ b/Google Play Music/Properties/Settings.settings
@@ -41,5 +41,11 @@
     <Setting Name="BetaStream" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
+    <Setting Name="PublishPlaybackInformation" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
+    <Setting Name="PublishPlaybackInformationPath" Type="System.String" Scope="User">
+      <Value Profile="(Default)">%USERPROFILE%\gpm-status.json</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/Google Play Music/Resources/JS/custom-interface.js
+++ b/Google Play Music/Resources/JS/custom-interface.js
@@ -73,8 +73,10 @@ csharpinterface.setInitialZoom();
 GPM.on('change:playback', function (mode) {
     if (mode === GMusic.Playback.STOPPED || mode === GMusic.Playback.PAUSED) {
         csharpinterface.setThumbbarToPlay();
+        csharpinterface.setPlaybackStatus(false);
     } else if (mode === GMusic.Playback.PLAYING) {
         csharpinterface.setThumbbarToPause();
+        csharpinterface.setPlaybackStatus(true);
     }
 });
 GPM.mini.on('enable', function (delay) {

--- a/Google Play Music/SettingsDialog.Designer.cs
+++ b/Google Play Music/SettingsDialog.Designer.cs
@@ -43,6 +43,8 @@
             this.updateStateText = new MaterialSkin.Controls.MaterialLabel();
             this.downloadProgressBorder = new MaterialSkin.Controls.MaterialDivider();
             this.installUpdateButton = new MaterialSkin.Controls.MaterialRaisedButton();
+            this.publishPlaybackInformation = new MaterialSkin.Controls.MaterialCheckBox();
+            this.publishPlaybackInformationPath = new MaterialSkin.Controls.MaterialSingleLineTextField();
             this.colorWheel1 = new Google_Play_Music.ColorWheel();
             this.SuspendLayout();
             // 
@@ -50,12 +52,12 @@
             // 
             this.materialLabel1.AutoSize = true;
             this.materialLabel1.Depth = 0;
-            this.materialLabel1.Font = new System.Drawing.Font("Microsoft Sans Serif", 11F);
+            this.materialLabel1.Font = new System.Drawing.Font("Roboto", 11F);
             this.materialLabel1.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(222)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));
             this.materialLabel1.Location = new System.Drawing.Point(411, 72);
             this.materialLabel1.MouseState = MaterialSkin.MouseState.HOVER;
             this.materialLabel1.Name = "materialLabel1";
-            this.materialLabel1.Size = new System.Drawing.Size(171, 18);
+            this.materialLabel1.Size = new System.Drawing.Size(176, 19);
             this.materialLabel1.TabIndex = 1;
             this.materialLabel1.Text = "Custom Theme Highlight";
             // 
@@ -63,7 +65,7 @@
             // 
             this.materialCheckBox1.AutoSize = true;
             this.materialCheckBox1.Depth = 0;
-            this.materialCheckBox1.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F);
+            this.materialCheckBox1.Font = new System.Drawing.Font("Roboto", 10F);
             this.materialCheckBox1.Location = new System.Drawing.Point(13, 97);
             this.materialCheckBox1.Margin = new System.Windows.Forms.Padding(0);
             this.materialCheckBox1.MouseLocation = new System.Drawing.Point(-1, -1);
@@ -79,12 +81,12 @@
             // 
             this.materialLabel2.AutoSize = true;
             this.materialLabel2.Depth = 0;
-            this.materialLabel2.Font = new System.Drawing.Font("Microsoft Sans Serif", 11F);
+            this.materialLabel2.Font = new System.Drawing.Font("Roboto", 11F);
             this.materialLabel2.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(222)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));
             this.materialLabel2.Location = new System.Drawing.Point(12, 71);
             this.materialLabel2.MouseState = MaterialSkin.MouseState.HOVER;
             this.materialLabel2.Name = "materialLabel2";
-            this.materialLabel2.Size = new System.Drawing.Size(117, 18);
+            this.materialLabel2.Size = new System.Drawing.Size(119, 19);
             this.materialLabel2.TabIndex = 3;
             this.materialLabel2.Text = "General Settings";
             // 
@@ -92,7 +94,7 @@
             // 
             this.materialCheckBox2.AutoSize = true;
             this.materialCheckBox2.Depth = 0;
-            this.materialCheckBox2.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F);
+            this.materialCheckBox2.Font = new System.Drawing.Font("Roboto", 10F);
             this.materialCheckBox2.Location = new System.Drawing.Point(13, 134);
             this.materialCheckBox2.Margin = new System.Windows.Forms.Padding(0);
             this.materialCheckBox2.MouseLocation = new System.Drawing.Point(-1, -1);
@@ -108,7 +110,7 @@
             // 
             this.materialCheckBox3.AutoSize = true;
             this.materialCheckBox3.Depth = 0;
-            this.materialCheckBox3.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F);
+            this.materialCheckBox3.Font = new System.Drawing.Font("Roboto", 10F);
             this.materialCheckBox3.Location = new System.Drawing.Point(13, 171);
             this.materialCheckBox3.Margin = new System.Windows.Forms.Padding(0);
             this.materialCheckBox3.MouseLocation = new System.Drawing.Point(-1, -1);
@@ -124,12 +126,12 @@
             // 
             this.materialLabel3.AutoSize = true;
             this.materialLabel3.Depth = 0;
-            this.materialLabel3.Font = new System.Drawing.Font("Microsoft Sans Serif", 11F);
+            this.materialLabel3.Font = new System.Drawing.Font("Roboto", 11F);
             this.materialLabel3.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(222)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));
-            this.materialLabel3.Location = new System.Drawing.Point(12, 248);
+            this.materialLabel3.Location = new System.Drawing.Point(12, 311);
             this.materialLabel3.MouseState = MaterialSkin.MouseState.HOVER;
             this.materialLabel3.Name = "materialLabel3";
-            this.materialLabel3.Size = new System.Drawing.Size(115, 18);
+            this.materialLabel3.Size = new System.Drawing.Size(120, 19);
             this.materialLabel3.TabIndex = 7;
             this.materialLabel3.Text = "Last.fm Account";
             // 
@@ -137,7 +139,7 @@
             // 
             this.lastFMUsername.Depth = 0;
             this.lastFMUsername.Hint = "";
-            this.lastFMUsername.Location = new System.Drawing.Point(12, 270);
+            this.lastFMUsername.Location = new System.Drawing.Point(12, 333);
             this.lastFMUsername.MaxLength = 32767;
             this.lastFMUsername.MouseState = MaterialSkin.MouseState.HOVER;
             this.lastFMUsername.Name = "lastFMUsername";
@@ -155,7 +157,7 @@
             // 
             this.lastFMPassword.Depth = 0;
             this.lastFMPassword.Hint = "";
-            this.lastFMPassword.Location = new System.Drawing.Point(12, 299);
+            this.lastFMPassword.Location = new System.Drawing.Point(12, 362);
             this.lastFMPassword.MaxLength = 32767;
             this.lastFMPassword.MouseState = MaterialSkin.MouseState.HOVER;
             this.lastFMPassword.Name = "lastFMPassword";
@@ -174,12 +176,12 @@
             // 
             this.lastFMAuthIndicator.AutoSize = true;
             this.lastFMAuthIndicator.Depth = 0;
-            this.lastFMAuthIndicator.Font = new System.Drawing.Font("Microsoft Sans Serif", 11F);
+            this.lastFMAuthIndicator.Font = new System.Drawing.Font("Roboto", 11F);
             this.lastFMAuthIndicator.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(222)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));
-            this.lastFMAuthIndicator.Location = new System.Drawing.Point(29, 325);
+            this.lastFMAuthIndicator.Location = new System.Drawing.Point(29, 388);
             this.lastFMAuthIndicator.MouseState = MaterialSkin.MouseState.HOVER;
             this.lastFMAuthIndicator.Name = "lastFMAuthIndicator";
-            this.lastFMAuthIndicator.Size = new System.Drawing.Size(124, 18);
+            this.lastFMAuthIndicator.Size = new System.Drawing.Size(131, 19);
             this.lastFMAuthIndicator.TabIndex = 10;
             this.lastFMAuthIndicator.Text = "Not Authenticated";
             // 
@@ -187,8 +189,8 @@
             // 
             this.materialCheckBox4.AutoSize = true;
             this.materialCheckBox4.Depth = 0;
-            this.materialCheckBox4.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F);
-            this.materialCheckBox4.Location = new System.Drawing.Point(12, 208);
+            this.materialCheckBox4.Font = new System.Drawing.Font("Roboto", 10F);
+            this.materialCheckBox4.Location = new System.Drawing.Point(13, 208);
             this.materialCheckBox4.Margin = new System.Windows.Forms.Padding(0);
             this.materialCheckBox4.MouseLocation = new System.Drawing.Point(-1, -1);
             this.materialCheckBox4.MouseState = MaterialSkin.MouseState.HOVER;
@@ -213,7 +215,7 @@
             // updateStateText
             // 
             this.updateStateText.Depth = 0;
-            this.updateStateText.Font = new System.Drawing.Font("Microsoft Sans Serif", 11F);
+            this.updateStateText.Font = new System.Drawing.Font("Roboto", 11F);
             this.updateStateText.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(222)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));
             this.updateStateText.Location = new System.Drawing.Point(405, 298);
             this.updateStateText.MouseState = MaterialSkin.MouseState.HOVER;
@@ -245,6 +247,40 @@
             this.installUpdateButton.Text = "Install Update";
             this.installUpdateButton.UseVisualStyleBackColor = true;
             // 
+            // publishPlaybackInformation
+            // 
+            this.publishPlaybackInformation.AutoSize = true;
+            this.publishPlaybackInformation.Depth = 0;
+            this.publishPlaybackInformation.Font = new System.Drawing.Font("Roboto", 10F);
+            this.publishPlaybackInformation.Location = new System.Drawing.Point(13, 245);
+            this.publishPlaybackInformation.Margin = new System.Windows.Forms.Padding(0);
+            this.publishPlaybackInformation.MouseLocation = new System.Drawing.Point(-1, -1);
+            this.publishPlaybackInformation.MouseState = MaterialSkin.MouseState.HOVER;
+            this.publishPlaybackInformation.Name = "publishPlaybackInformation";
+            this.publishPlaybackInformation.Ripple = true;
+            this.publishPlaybackInformation.Size = new System.Drawing.Size(241, 30);
+            this.publishPlaybackInformation.TabIndex = 16;
+            this.publishPlaybackInformation.Text = "Store Playback Information in File:";
+            this.publishPlaybackInformation.UseVisualStyleBackColor = true;
+            // 
+            // publishPlaybackInformationPath
+            // 
+            this.publishPlaybackInformationPath.Depth = 0;
+            this.publishPlaybackInformationPath.Hint = "";
+            this.publishPlaybackInformationPath.Location = new System.Drawing.Point(44, 278);
+            this.publishPlaybackInformationPath.MaxLength = 32767;
+            this.publishPlaybackInformationPath.MouseState = MaterialSkin.MouseState.HOVER;
+            this.publishPlaybackInformationPath.Name = "publishPlaybackInformationPath";
+            this.publishPlaybackInformationPath.PasswordChar = '\0';
+            this.publishPlaybackInformationPath.SelectedText = "";
+            this.publishPlaybackInformationPath.SelectionLength = 0;
+            this.publishPlaybackInformationPath.SelectionStart = 0;
+            this.publishPlaybackInformationPath.Size = new System.Drawing.Size(251, 23);
+            this.publishPlaybackInformationPath.TabIndex = 17;
+            this.publishPlaybackInformationPath.TabStop = false;
+            this.publishPlaybackInformationPath.Text = "%USERPROFILE%\\gpm-status.json";
+            this.publishPlaybackInformationPath.UseSystemPasswordChar = false;
+            // 
             // colorWheel1
             // 
             this.colorWheel1.Hue = ((byte)(0));
@@ -261,7 +297,9 @@
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(600, 360);
+            this.ClientSize = new System.Drawing.Size(600, 423);
+            this.Controls.Add(this.publishPlaybackInformationPath);
+            this.Controls.Add(this.publishPlaybackInformation);
             this.Controls.Add(this.installUpdateButton);
             this.Controls.Add(this.updateStateText);
             this.Controls.Add(this.downloadProgress);
@@ -278,6 +316,7 @@
             this.Controls.Add(this.colorWheel1);
             this.Controls.Add(this.downloadProgressBorder);
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
+            this.Location = new System.Drawing.Point(0, 0);
             this.MaximizeBox = false;
             this.MinimizeBox = false;
             this.Name = "SettingsDialog";
@@ -304,5 +343,7 @@
         private MaterialSkin.Controls.MaterialLabel updateStateText;
         private MaterialSkin.Controls.MaterialDivider downloadProgressBorder;
         private MaterialSkin.Controls.MaterialRaisedButton installUpdateButton;
+        private MaterialSkin.Controls.MaterialCheckBox publishPlaybackInformation;
+        private MaterialSkin.Controls.MaterialSingleLineTextField publishPlaybackInformationPath;
     }
 }

--- a/Google Play Music/SettingsDialog.cs
+++ b/Google Play Music/SettingsDialog.cs
@@ -92,6 +92,23 @@ namespace Google_Play_Music
                 Properties.Settings.Default.MiniAlwaysOnTop = materialCheckBox4.Checked;
             };
 
+            publishPlaybackInformation.Checked = Properties.Settings.Default.PublishPlaybackInformation;
+            publishPlaybackInformation.CheckStateChanged += (res, send) =>
+            {
+                publishPlaybackInformationPath.Enabled = publishPlaybackInformation.Checked;
+            };
+
+            publishPlaybackInformationPath.Enabled = publishPlaybackInformation.Checked;
+
+            FormClosing += (send, ev) =>
+            {
+                Properties.Settings.Default.PublishPlaybackInformation = publishPlaybackInformation.Checked;
+                Properties.Settings.Default.PublishPlaybackInformationPath = publishPlaybackInformationPath.Text;
+                PlayStatus.Instance.UpdateSettings();
+                PlayStatus.Instance.Update();
+            };
+
+
             lastFMUsername.Text = Properties.Settings.Default.LastFMUsername;
             lastFMUsername.GotFocus += (res, send) =>
             {
@@ -251,5 +268,6 @@ namespace Google_Play_Music
                 lastFMAuthIndicator.Text = "Logging in...";
             }
         }
+
     }
 }


### PR DESCRIPTION
### Description
This feature allows users to store information about the playback status
in a JSON-formatted file. The feature is disabled by default, users have
to manually opt-in through their desktop settings.

The playback information can be used to give external programs access to
the current song and playback status, for instance Twitch streamers
might want to display the currently played song.

These are the attributes of the playback information file:
- **isPlaying**: (bool) Whether or not a song is currently playing
- **song**: (string) The name of the current song
- **artist**: (string) The artist of the current song
- **album**: (string) The album of the current song
- **imageURL**: (string) An URL to the current song's album or song image

This is how the new setting looks in the desktop settings screen:
![Image of the new Store Playback Information in File setting](https://monosnap.com/file/tdCdIXJuKWxpC6PcAJmgcZ5TAbmVpQ.png)

### Changes

All changes should be self-explanatory, but just to make sure:
- Desktop Settings UI is changed to reflect the new option.
- PlayStatus class is introduced to manage the current playback status.
- New JavaScript interface setPlaybackStatus is introduced to
  update the "isPlaying" attribute of the playback information.
- The existing JavaScript interface songChangeEvent is used to update
  the song, artist, album, and imageURL attributes of the playback
  information.
- The FormClosing event of the main application is used to set the
  isPlaying attribute to "false" just before the player closes so the
  file reflects the state properly.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/marshallofsound/google-play-music-desktop-player-unofficial-/155)
<!-- Reviewable:end -->
