### PR TITLE
Fix Mac Fullscreen

### DIFF
--- a/src/main/features/core/controlBar.js
+++ b/src/main/features/core/controlBar.js
@@ -4,10 +4,19 @@ Emitter.on('window:minimize', (event, windowID) => {
 
 Emitter.on('window:maximize', (event, windowID) => {
   const window = WindowManager.getByInternalID(windowID);
-  if (window.isMaximized()) {
-    WindowManager.getByInternalID(windowID).unmaximize();
+
+  if (process.platform === 'darwin') {
+    if (window.isFullScreen()) {
+      window.setFullScreen(false);
+    } else {
+      window.setFullScreen(true);
+    }
   } else {
-    WindowManager.getByInternalID(windowID).maximize();
+    if (window.isMaximized()) {
+      window.unmaximize();
+    } else {
+      window.maximize();
+    }
   }
 });
 


### PR DESCRIPTION
Looking at the [electron docs](http://electron.atom.io/docs/latest/api/browser-window/), `{fullscreenable: true}` (which should be true by default) should work in the place of this in the index.js. I attempted to modify the `baseConfig` with this and it didn't seem to work. I haven't looked into electron itself, but using `mainWindow.setFullScreenable(true); ` as a workaround after init seems to work for me on OS X 10.11.3.

Adds a separate maximize toggle path for `darwin`. 

`WindowManager.getByInternalID(windowID)` calls removed since the `window`/`windowID` doesn't change. Not super related to the feature pull.

Addresses part of #212.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/marshallofsound/google-play-music-desktop-player-unofficial-/221)
<!-- Reviewable:end -->
