### PR TITLE
rpm and deb packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,4 @@
 node_modules/
 build/
-dist/*
-!dist/installers/
-!dist/installers/*
-dist/installers/installers.zip
+dist/
 .settings.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 node_modules/
 build/
-dist/
+dist/*
+!dist/installers/
+!dist/installers/*
+dist/installers/installers.zip
 .settings.json

--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ OS Support
 * Windows 7 or later
 * Mac OSX 10.8.0 or later
 * Ubuntu 14.04 or later
+* Mint
+* Fedora
+* Debian
 
 **Note: We do not current have automated builds for Ubuntu (PR's are welcome)**
 
@@ -76,6 +79,12 @@ npm run make:win
 
 # Mac OSX
 npm run make:darwin
+
+# Ubuntu
+npm run make:deb
+
+# Fedora
+npm run make:rpm
 ```
 
 All releases will be signing with my Code Signing Certificates (Authenticode on Windows and Codesign on OSX)

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -30,6 +30,9 @@ const paths = {
   images: ['src/assets/icons/**/*', 'src/assets/img/**/*'],
 };
 
+var repo_website = 'http://www.googleplaymusicdesktopplayer.com';
+var repo_author = 'Samuel Attard <samuel.r.attard@gmail.com>';
+
 const packageJSON = require('./package.json');
 let version = packageJSON.dependencies['electron-prebuilt'];
 if (version.substr(0, 1) !== '0') {
@@ -199,6 +202,51 @@ gulp.task('package:linux', ['clean-dist-linux', 'build'], (done) => {
   packager(_.extend({}, defaultPackageConf, { platform: 'linux' }), done);
 });
 
+<<<<<<< 85927e4c4988878901bc2e1a04266ca0efd05542
+=======
+gulp.task('rpm:linux', ['package:linux'], (done) => {
+  let count = 0;
+  const next = (err) => {
+    if (err) {
+      done(err);
+    } else if (count > 0) {
+      done();
+    } else {
+      count++;
+    }
+  };
+
+  const redhat = require('electron-installer-redhat');
+
+  const defaults = {
+    bin: packageJSON.productName,
+    dest: 'dist/installers',
+    depends: ['libappindicator1'],
+    maintainer: repo_author,
+    homepage: repo_website,
+    icon: 'build/assets/img/main.png',
+  };
+
+  redhat(_.extend({}, defaults, {
+    src: `dist/${packageJSON.productName}-linux-ia32`,
+    arch: 'i386',
+  }), (err) => {
+    console.log('32bit redhat package built');
+    if (err) return next(err);
+    next();
+  });
+
+  redhat(_.extend({}, defaults, {
+    src: `dist/${packageJSON.productName}-linux-x64`,
+    arch: 'amd64',
+  }), (err) => {
+    console.log('64bit redhat package built');
+    if (err) return next(err);
+    next();
+  });
+});
+
+>>>>>>> added support for rpm
 gulp.task('deb:linux', ['package:linux'], (done) => {
   let count = 0;
   const next = (err) => {
@@ -217,8 +265,13 @@ gulp.task('deb:linux', ['package:linux'], (done) => {
     bin: packageJSON.productName,
     dest: 'dist/installers',
     depends: ['libappindicator1'],
+<<<<<<< 85927e4c4988878901bc2e1a04266ca0efd05542
     maintainer: 'Samuel Attard <samuel.r.attard@gmail.com>',
     homepage: 'http://www.googleplaymusicdesktopplayer.com',
+=======
+    maintainer: repo_author,
+    homepage: repo_website,
+>>>>>>> added support for rpm
     icon: 'build/assets/img/main.png',
   };
 
@@ -226,7 +279,11 @@ gulp.task('deb:linux', ['package:linux'], (done) => {
     src: `dist/${packageJSON.productName}-linux-ia32`,
     arch: 'i386',
   }), (err) => {
+<<<<<<< 85927e4c4988878901bc2e1a04266ca0efd05542
     console.log('32bit package built');
+=======
+    console.log('32bit deb package built');
+>>>>>>> added support for rpm
     if (err) return next(err);
     next();
   });
@@ -235,13 +292,73 @@ gulp.task('deb:linux', ['package:linux'], (done) => {
     src: `dist/${packageJSON.productName}-linux-x64`,
     arch: 'amd64',
   }), (err) => {
+<<<<<<< 85927e4c4988878901bc2e1a04266ca0efd05542
     console.log('64bit package built');
+=======
+    console.log('64bit deb package built');
+>>>>>>> added support for rpm
     if (err) return next(err);
     next();
   });
 });
 
+<<<<<<< 85927e4c4988878901bc2e1a04266ca0efd05542
 gulp.task('make:linux', ['deb:linux'], (done) => {
+=======
+gulp.task('make:deb', ['deb:linux'], (done) => {
+
+  // Zip Linux x86
+  const child = spawn('zip', ['-r', '-y',
+    `installers.zip`,
+    `.`],
+    {
+      cwd: `./dist/installers`,
+    });
+
+  console.log(`Zipping the linux Installers`); // eslint-disable-line
+
+  // spit stdout to screen
+  child.stdout.on('data', (data) => { process.stdout.write(data.toString()); });
+
+  // Send stderr to the main console
+  child.stderr.on('data', (data) => {
+    process.stdout.write(data.toString());
+  });
+
+  child.on('close', (code) => {
+    console.log('Finished zipping with code ' + code); // eslint-disable-line
+    done();
+  });
+});
+
+gulp.task('make:rpm', ['deb:redhat'], (done) => {
+
+  // Zip Linux x86
+  const child = spawn('zip', ['-r', '-y',
+    `installers.zip`,
+    `.`],
+    {
+      cwd: `./dist/installers`,
+    });
+
+  console.log(`Zipping the linux Installers`); // eslint-disable-line
+
+  // spit stdout to screen
+  child.stdout.on('data', (data) => { process.stdout.write(data.toString()); });
+
+  // Send stderr to the main console
+  child.stderr.on('data', (data) => {
+    process.stdout.write(data.toString());
+  });
+
+  child.on('close', (code) => {
+    console.log('Finished zipping with code ' + code); // eslint-disable-line
+    done();
+  });
+});
+
+gulp.task('make:linux', ['deb:linux', 'rpm:linux'], (done) => {
+>>>>>>> added support for rpm
   // Zip Linux x86
   const child = spawn('zip', ['-r', '-y',
     `installers.zip`,

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -30,8 +30,8 @@ const paths = {
   images: ['src/assets/icons/**/*', 'src/assets/img/**/*'],
 };
 
-var repo_website = 'http://www.googleplaymusicdesktopplayer.com';
-var repo_author = 'Samuel Attard <samuel.r.attard@gmail.com>';
+const repo_website = 'http://www.googleplaymusicdesktopplayer.com';
+const repo_author = 'Samuel Attard <samuel.r.attard@gmail.com>';
 
 const packageJSON = require('./package.json');
 let version = packageJSON.dependencies['electron-prebuilt'];

--- a/package.json
+++ b/package.json
@@ -1,4 +1,8 @@
 {
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/MarshallOfSound/Google-Play-Music-Desktop-Player-UNOFFICIAL-"
+  },
   "name": "google-play-music-desktop-player",
   "productName": "Google Play Music Desktop Player",
   "version": "3.0.0",
@@ -11,6 +15,11 @@
     "make:win": "gulp make:win",
     "make:darwin": "gulp make:darwin",
     "make:linux": "gulp make:linux",
+<<<<<<< 85927e4c4988878901bc2e1a04266ca0efd05542
+=======
+    "make:deb": "gulp make:deb",
+    "make:rpm": "gulp make:rpm",
+>>>>>>> added support for rpm
     "package:darwin": "gulp package:darwin",
     "package:win": "gulp package:win",
     "package:linux": "gulp package:linux",
@@ -69,6 +78,11 @@
     "sinon-chai": "^2.8.0"
   },
   "optionalDependencies": {
+<<<<<<< 85927e4c4988878901bc2e1a04266ca0efd05542
     "electron-installer-debian": "^0.2.0"
+=======
+    "electron-installer-debian": "^0.2.0",
+    "electron-installer-redhat": "^0.2.0"
+>>>>>>> added support for rpm
   }
 }


### PR DESCRIPTION
Added options to make packages for more platforms.
npm run make:deb
npm run make:rpm
to replace make:linux

Packages should work for Ubuntu/Mint/Fedora/Debian. Hoping to get one for Arch. Will probably add some testing for the linux platforms.

Included the actual packages in ./dist/installers/

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/marshallofsound/google-play-music-desktop-player-unofficial-/241)
<!-- Reviewable:end -->
