### PR TITLE
rpm and deb packages round two

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ OS Support
 * Windows 7 or later
 * Mac OSX 10.8.0 or later
 * Ubuntu 14.04 or later
+* Mint
+* Fedora
+* Debian
 
 **Note: We do not current have automated builds for Ubuntu (PR's are welcome)**
 
@@ -76,6 +79,12 @@ npm run make:win
 
 # Mac OSX
 npm run make:darwin
+
+# Ubuntu
+npm run make:deb
+
+# Fedora
+npm run make:rpm
 ```
 
 All releases will be signing with my Code Signing Certificates (Authenticode on Windows and Codesign on OSX)

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -215,7 +215,7 @@ gulp.task('deb:linux', ['package:linux'], (done) => {
 
   const defaults = {
     bin: packageJSON.productName,
-    dest: 'dist/installers',
+    dest: 'dist/installers/debian',
     depends: ['libappindicator1'],
     maintainer: 'Samuel Attard <samuel.r.attard@gmail.com>',
     homepage: 'http://www.googleplaymusicdesktopplayer.com',
@@ -257,7 +257,7 @@ gulp.task('rpm:linux', ['package:linux'], (done) => {
 
   const defaults = {
     bin: packageJSON.productName,
-    dest: 'dist/installers',
+    dest: 'dist/installers/fedora',
     depends: ['libappindicator1'],
     maintainer: 'Samuel Attard <samuel.r.attard@gmail.com>',
     homepage: 'http://www.googleplaymusicdesktopplayer.com',
@@ -314,7 +314,7 @@ gulp.task('make:deb', ['deb:linux'], (done) => {
     `installers.zip`,
     `.`],
     {
-      cwd: `./dist/installers`,
+      cwd: `./dist/installers/debian`,
     });
 
   console.log(`Zipping the linux Installers`); // eslint-disable-line
@@ -339,7 +339,7 @@ gulp.task('make:rpm', ['deb:redhat'], (done) => {
     `installers.zip`,
     `.`],
     {
-      cwd: `./dist/installers`,
+      cwd: `./dist/installers/rpm`,
     });
 
   console.log(`Zipping the linux Installers`); // eslint-disable-line

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -226,7 +226,7 @@ gulp.task('deb:linux', ['package:linux'], (done) => {
     src: `dist/${packageJSON.productName}-linux-ia32`,
     arch: 'i386',
   }), (err) => {
-    console.log('32bit package built');
+    console.log('32bit deb package built');
     if (err) return next(err);
     next();
   });
@@ -235,13 +235,105 @@ gulp.task('deb:linux', ['package:linux'], (done) => {
     src: `dist/${packageJSON.productName}-linux-x64`,
     arch: 'amd64',
   }), (err) => {
-    console.log('64bit package built');
+    console.log('64bit deb package built');
     if (err) return next(err);
     next();
   });
 });
 
-gulp.task('make:linux', ['deb:linux'], (done) => {
+gulp.task('rpm:linux', ['package:linux'], (done) => {
+  let count = 0;
+  const next = (err) => {
+    if (err) {
+      done(err);
+    } else if (count > 0) {
+      done();
+    } else {
+      count++;
+    }
+  };
+
+  const redhat  = require('electron-installer-redhat');
+
+  const defaults = {
+    bin: packageJSON.productName,
+    dest: 'dist/installers',
+    depends: ['libappindicator1'],
+    maintainer: 'Samuel Attard <samuel.r.attard@gmail.com>',
+    homepage: 'http://www.googleplaymusicdesktopplayer.com',
+    icon: 'build/assets/img/main.png',
+  };
+
+  redhat(_.extend({}, defaults, {
+    src: `dist/${packageJSON.productName}-linux-ia32`,
+    arch: 'i386',
+  }), (err) => {
+    console.log('32bit rpm package built');
+    if (err) return next(err);
+    next();
+  });
+
+  redhat(_.extend({}, defaults, {
+    src: `dist/${packageJSON.productName}-linux-x64`,
+    arch: 'amd64',
+  }), (err) => {
+    console.log('64bit rpm package built');
+    if (err) return next(err);
+    next();
+  });
+});
+
+gulp.task('make:linux', ['deb:linux', 'rpm:linux'], (done) => {
+  // Zip Linux x86
+  const child = spawn('zip', ['-r', '-y',
+    `installers.zip`,
+    `.`],
+    {
+      cwd: `./dist/installers`,
+    });
+
+  console.log(`Zipping the linux Installers`); // eslint-disable-line
+
+  // spit stdout to screen
+  child.stdout.on('data', (data) => { process.stdout.write(data.toString()); });
+
+  // Send stderr to the main console
+  child.stderr.on('data', (data) => {
+    process.stdout.write(data.toString());
+  });
+
+  child.on('close', (code) => {
+    console.log('Finished zipping with code ' + code); // eslint-disable-line
+    done();
+  });
+});
+
+gulp.task('make:deb', ['deb:linux'], (done) => {
+  // Zip Linux x86
+  const child = spawn('zip', ['-r', '-y',
+    `installers.zip`,
+    `.`],
+    {
+      cwd: `./dist/installers`,
+    });
+
+  console.log(`Zipping the linux Installers`); // eslint-disable-line
+
+  // spit stdout to screen
+  child.stdout.on('data', (data) => { process.stdout.write(data.toString()); });
+
+  // Send stderr to the main console
+  child.stderr.on('data', (data) => {
+    process.stdout.write(data.toString());
+  });
+
+  child.on('close', (code) => {
+    console.log('Finished zipping with code ' + code); // eslint-disable-line
+    done();
+  });
+});
+
+gulp.task('make:rpm', ['deb:redhat'], (done) => {
   // Zip Linux x86
   const child = spawn('zip', ['-r', '-y',
     `installers.zip`,

--- a/package.json
+++ b/package.json
@@ -1,4 +1,8 @@
 {
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/MarshallOfSound/Google-Play-Music-Desktop-Player-UNOFFICIAL-"
+  },
   "name": "google-play-music-desktop-player",
   "productName": "Google Play Music Desktop Player",
   "version": "3.0.0",
@@ -11,6 +15,8 @@
     "make:win": "gulp make:win",
     "make:darwin": "gulp make:darwin",
     "make:linux": "gulp make:linux",
+    "make:deb": "gulp make:deb",
+    "make:rpm": "gulp make:rpm",
     "package:darwin": "gulp package:darwin",
     "package:win": "gulp package:win",
     "package:linux": "gulp package:linux",
@@ -69,6 +75,7 @@
     "sinon-chai": "^2.8.0"
   },
   "optionalDependencies": {
-    "electron-installer-debian": "^0.2.0"
+    "electron-installer-debian": "^0.2.0",
+    "electron-installer-redhat": "^0.2.0"
   }
 }


### PR DESCRIPTION
Added options to make packages for more platforms.
npm run make:deb
npm run make:rpm

npm run make:linux will build both assuming you have apt and rpm.

Can probably shorten the code, a bit of redundant stuff going on, but wouldn't change performance.

Packages should work for Ubuntu/Mint/Fedora/Debian. Hoping to get one for Arch. Will probably add some testing for the linux platforms. Or might look through the issues.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/marshallofsound/google-play-music-desktop-player-unofficial-/244)
<!-- Reviewable:end -->
