### PR TITLE
Increase settings window height to fit contents.

### DIFF
--- a/src/main/features/core/desktopSettings.js
+++ b/src/main/features/core/desktopSettings.js
@@ -8,7 +8,7 @@ export const showDesktopSettings = () => {
   }
   const desktopSettings = new BrowserWindow({
     width: 800,
-    height: 400,
+    height: 480,
     frame: false,
     show: false,
     nodeIntegration: true,


### PR DESCRIPTION
There are two tabs in the settings that must scroll (General and Hotkeys, though Hotkeys doesn't have any hidden content).

This fixes #240

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/marshallofsound/google-play-music-desktop-player-unofficial-/272)
<!-- Reviewable:end -->
