### PR TITLE
Playback & like buttons in tray menu. Toggle minimize on tray left click.

### DIFF
--- a/src/main/features/core/tray.js
+++ b/src/main/features/core/tray.js
@@ -27,6 +27,29 @@ const setContextMenu = () => {
         mainWindow.show();
       },
     },
+    { type: 'separator' },
+    {
+      label: 'Play / Pause',
+      click: () => Emitter.sendToGooglePlayMusic('playback:playPause'),
+    },
+    {
+      label: 'Previous Track',
+      click: () => Emitter.sendToGooglePlayMusic('playback:previousTrack'),
+    },
+    {
+      label: 'Next Track',
+      click: () => Emitter.sendToGooglePlayMusic('playback:nextTrack'),
+    },
+    { type: 'separator' },
+    {
+      label: 'Thumbs Up',
+      click: () => Emitter.sendToGooglePlayMusic('playback:thumbsUp'),
+    },
+    {
+      label: 'Thumbs Down',
+      click: () => Emitter.sendToGooglePlayMusic('playback:thumbsDown'),
+    },
+    { type: 'separator' },
     {
       label: 'Audio Device',
       submenu: audioDeviceMenu,
@@ -40,10 +63,63 @@ const setContextMenu = () => {
 setContextMenu();
 
 appIcon.setToolTip('Google Play Music');
-appIcon.on('double-click', () => {
-  mainWindow.setSkipTaskbar(false);
-  mainWindow.show();
-});
+
+
+// Iconified     -> show, to foreground
+// In background -> to foreground
+// In foreground -> iconify
+function toggleMainWindow() {
+  // The mainWindow variable may be GC'd
+  const win = WindowManager.getAll('main')[0];
+
+  if (process.platform === 'darwin') { // OS-X - Not tested!
+    if (!win.isVisible()) {
+      // Show
+      win.setSkipTaskbar(false);
+      win.show();
+    } else {
+      // Hide to tray, if configured
+      if (Settings.get('minToTray', true)) {
+        win.hide();
+      }
+    }
+  } else { // Windows, Linux
+    const minimized = win.isMinimized();
+
+    if (minimized || !win.isFocused()) {
+      // Window in tray, or not focused
+      win.setSkipTaskbar(false);
+      win.show();
+      win.focus(); // if not minimized, just raise focus
+
+      if (!minimized && !win.isFocused()) {
+        // Failed to focus the window !
+
+        // The window is in a weird state caused
+        // by closing it with the cross button
+
+        console.error('Window is in a non-focusable glitch state.');
+
+        // since we can't bring it to foreground, toggle it at least.
+        if (Settings.get('minToTray', true)) {
+          win.minimize();
+          win.setSkipTaskbar(true);
+        }
+      }
+
+    } else {
+      // Hide to tray, if configured
+      if (Settings.get('minToTray', true)) {
+        win.minimize();
+        win.setSkipTaskbar(true);
+      }
+    }
+  }
+}
+
+appIcon.on('click', toggleMainWindow);
+appIcon.on('double-click', toggleMainWindow);
+
 
 // DEV: Keep the icon in the global scope or it gets garbage collected........
 global.appIcon = appIcon;


### PR DESCRIPTION
This pull request addresses my issue #276.

It adds some useful buttons to the tray menu, and also left-clicking the tray button toggles the app window, like in almost all Linux apps (before it was double-click and could not close, only open).

I hope it'll be ok on Windows and Mac, can't try it myself.

![screenshot_20160306_195211](https://cloud.githubusercontent.com/assets/2041118/13556306/cc8fd81a-e3d6-11e5-82ec-b04e42a1f690.png)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/marshallofsound/google-play-music-desktop-player-unofficial-/278)
<!-- Reviewable:end -->
