### PR TITLE
Added hotkeys for volume control

### DIFF
--- a/src/inject/GPMInject/playback/controller.js
+++ b/src/inject/GPMInject/playback/controller.js
@@ -31,3 +31,11 @@ Emitter.on('playback:thumbsUp', () => {
 Emitter.on('playback:thumbsDown', () => {
   window.GPM.rating.setRating(1);
 });
+
+Emitter.on('playback:increaseVolume', () => {
+  window.GPM.volume.increaseVolume();
+});
+
+Emitter.on('playback:decreaseVolume', () => {
+  window.GPM.volume.decreaseVolume();
+});

--- a/src/main/features/core/keyboardShotcuts.js
+++ b/src/main/features/core/keyboardShotcuts.js
@@ -17,14 +17,21 @@ globalShortcut.register('MediaStop', () => {
   Emitter.sendToGooglePlayMusic('playback:stop');
 });
 
-const customHotkeys = Settings.get('hotkeys', {
+const customHotkeysTemplate = {
   playPause: null,
   stop: null,
   previousTrack: null,
   nextTrack: null,
   thumbsUp: null,
   thumbsDown: null,
-});
+  increaseVolume: null,
+  decreaseVolume: null,
+};
+
+const userHotkeys = Settings.get('hotkeys', {});
+
+const customHotkeys = _.extend(customHotkeysTemplate, userHotkeys);
+
 
 _.forIn(customHotkeys, (value, key) => {
   if (value) {
@@ -36,6 +43,7 @@ _.forIn(customHotkeys, (value, key) => {
 
 Emitter.on('hotkey:set', (event, details) => {
   const key = details.action;
+
   if (customHotkeys[key] || customHotkeys[key] === null) {
     if (customHotkeys[key] && globalShortcut.isRegistered(customHotkeys[key])) {
       globalShortcut.unregister(customHotkeys[key]);

--- a/src/public_html/desktop_settings.html
+++ b/src/public_html/desktop_settings.html
@@ -126,6 +126,16 @@
                 <label for="last_name">Thumbs Down Current Song</label>
               </div>
             </div>
+            <div class="row">
+              <div class="input-field col s6">
+                <input placeholder="Not Set" id="decreaseVolume" type="text">
+                <label for="first_name">Decrease Volume</label>
+              </div>
+              <div class="input-field col s6">
+                <input placeholder="Not Set" id="increaseVolume" type="text">
+                <label for="last_name">Increase Volume</label>
+              </div>
+            </div>
           </div>
           <div id="audio" class="col s12 settings-box">
             <div class="input-field col s12">


### PR DESCRIPTION
Solves issue #274

Hotkeys can now be assigned for volume control.

Also solves a problem where new hotkeys could not be added to the `customHotkeys` dict, if user already saved the settings.