### PR TITLE
Use hidden directory for config on Linux

### DIFF
--- a/src/main/utils/PlaybackAPI.js
+++ b/src/main/utils/PlaybackAPI.js
@@ -1,14 +1,9 @@
 import fs from 'fs';
-import mkdirp from 'mkdirp';
-import config_dir from './config_dir';
-
-const os = require('os');
-
-const environment = process.env;
+import configDir from './configDir';
 
 class PlaybackAPI {
   constructor() {
-    this.PATH = `${config_dir}/playback.json`;
+    this.PATH = `${configDir}/playback.json`;
 
     this.reset();
 

--- a/src/main/utils/PlaybackAPI.js
+++ b/src/main/utils/PlaybackAPI.js
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import mkdirp from 'mkdirp';
+import config_dir from './config_dir';
 
 const os = require('os');
 
@@ -7,15 +8,11 @@ const environment = process.env;
 
 class PlaybackAPI {
   constructor() {
-    const DIR = (environment.APPDATA ||
-      (process.platform === 'darwin' ? environment.HOME + '/Library/Preferences' : os.homedir())) +
-      '/GPMDP_STORE';
-    this.PATH = `${DIR}/playback.json`;
+    this.PATH = `${config_dir}/playback.json`;
 
     this.reset();
 
     if (!fs.existsSync(this.PATH)) {
-      mkdirp(DIR);
       this._save();
     }
 

--- a/src/main/utils/Settings.js
+++ b/src/main/utils/Settings.js
@@ -1,15 +1,10 @@
 import fs from 'fs';
-import mkdirp from 'mkdirp';
 import initalSettings from './initialSettings';
-import config_dir from './config_dir';
-
-const os = require('os');
-
-const environment = process.env;
+import configDir from './configDir';
 
 class Settings {
   constructor(jsonPrefix, wipeOldData) {
-    this.PATH = `${config_dir}/${(jsonPrefix || '')}.settings.json`;
+    this.PATH = `${configDir}/${(jsonPrefix || '')}.settings.json`;
     this.data = initalSettings;
     this.lastSync = 0;
 

--- a/src/main/utils/Settings.js
+++ b/src/main/utils/Settings.js
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import mkdirp from 'mkdirp';
 import initalSettings from './initialSettings';
+import config_dir from './config_dir';
 
 const os = require('os');
 
@@ -8,17 +9,13 @@ const environment = process.env;
 
 class Settings {
   constructor(jsonPrefix, wipeOldData) {
-    const DIR = (environment.APPDATA ||
-      (process.platform === 'darwin' ? environment.HOME + '/Library/Preferences' : os.homedir())) +
-      '/GPMDP_STORE';
-    this.PATH = `${DIR}/${(jsonPrefix || '')}.settings.json`;
+    this.PATH = `${config_dir}/${(jsonPrefix || '')}.settings.json`;
     this.data = initalSettings;
     this.lastSync = 0;
 
     if (fs.existsSync(this.PATH) && !wipeOldData) {
       this._load();
     } else {
-      mkdirp.sync(DIR);
       this._save(true);
     }
     this.coupled = true;

--- a/src/main/utils/configDir.js
+++ b/src/main/utils/configDir.js
@@ -12,7 +12,7 @@ switch (process.platform) {
     DIR = os.homedir() + '/.GPMDP_STORE';
     break;
   case 'darwin':
-    DIR = environment.HOME + '/Library/Preferences/GPMDP_STORE'
+    DIR = environment.HOME + '/Library/Preferences/GPMDP_STORE';
     break;
   default:
     DIR = environment.APPDATA + '/GPMDP_STORE';

--- a/src/main/utils/config_dir.js
+++ b/src/main/utils/config_dir.js
@@ -1,0 +1,25 @@
+import fs from 'fs';
+import mkdirp from 'mkdirp';
+
+const os = require('os');
+const environment = process.env;
+
+// Resolve config directory
+
+let DIR;
+switch (process.platform) {
+  case 'linux':
+    DIR = os.homedir() + '/.GPMDP_STORE';
+    break;
+  case 'darwin':
+    DIR = environment.HOME + '/Library/Preferences/GPMDP_STORE'
+    break;
+  default:
+    DIR = environment.APPDATA + '/GPMDP_STORE';
+}
+
+if (!fs.existsSync(DIR)) {
+  mkdirp(DIR);
+}
+
+export default DIR;


### PR DESCRIPTION
This PR moves the config directory to `~/.GPMDP_STORE` - a hidden directory, as is customary on Linux.

Linux users go to great lengths to make the home dir tidy, and then there's this, in all caps and visible!
Small downside is that Linux users will lose their config with this update, but it's worth it.

I have also abstracted the config directory resolution to it's own file. Please check if it's still working OK on Win and Mac.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/marshallofsound/google-play-music-desktop-player-unofficial-/290)
<!-- Reviewable:end -->
