### PR TITLE
Option to disable the JSON API

### DIFF
--- a/src/main/utils/PlaybackAPI.js
+++ b/src/main/utils/PlaybackAPI.js
@@ -57,7 +57,9 @@ class PlaybackAPI {
   }
 
   _save() {
-    fs.writeFileSync(this.PATH, JSON.stringify(this.data));
+    if (Settings.get('enableJSONApi', true)) {
+      fs.writeFileSync(this.PATH, JSON.stringify(this.data));
+    }
   }
 
   setPlaying(isPlaying) {

--- a/src/main/utils/initialSettings.js
+++ b/src/main/utils/initialSettings.js
@@ -1,3 +1,4 @@
 export default {
   themeColor: '#2196F3',
+  enableJSONApi: true
 };

--- a/src/main/utils/initialSettings.js
+++ b/src/main/utils/initialSettings.js
@@ -1,4 +1,4 @@
 export default {
   themeColor: '#2196F3',
-  enableJSONApi: true
+  enableJSONApi: true,
 };


### PR DESCRIPTION
I'm afraid the way the API is done will cause harm to SSD drives and similar with limited number of write cycles. It writes the file every second!

Also not many people will use this, so why not have an option to disable it?

I have added a config key `"enableJSONApi"`, which is true by default, but can be disabled by editing the config file.

There is no toggle in the settings page, but I don't think it's necessary. It can be added later.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/marshallofsound/google-play-music-desktop-player-unofficial-/291)
<!-- Reviewable:end -->
