### PR TITLE
Main window toggle on tray icon click.

### DIFF
--- a/src/main/features/core/tray.js
+++ b/src/main/features/core/tray.js
@@ -75,7 +75,7 @@ function toggleMainWindow() {
 }
 
 appIcon.setToolTip('Google Play Music');
-//appIcon.on('double-click', toggleMainWindow);
+// appIcon.on('double-click', toggleMainWindow);
 appIcon.on('click', toggleMainWindow);
 
 

--- a/src/main/features/core/tray.js
+++ b/src/main/features/core/tray.js
@@ -95,7 +95,10 @@ function toggleMainWindow() {
 
 appIcon.setToolTip('Google Play Music');
 appIcon.on('click', toggleMainWindow);
-appIcon.on('double-click', toggleMainWindow);
+
+/* does not work if the 'click' handler is present */
+//appIcon.on('double-click', toggleMainWindow);
+
 
 // DEV: Keep the icon in the global scope or it gets garbage collected........
 global.appIcon = appIcon;

--- a/src/main/features/core/tray.js
+++ b/src/main/features/core/tray.js
@@ -61,7 +61,7 @@ function toggleMainWindow() {
 appIcon.setToolTip('Google Play Music');
 
 switch (process.platform) {
-  case 'darwin': // actually means OS-X
+  case 'darwin': // <- actually means OS-X
     // No toggle action, use the context menu.
     break;
   case 'linux':
@@ -71,6 +71,9 @@ switch (process.platform) {
     break;
   case 'win32': // <- it's win32 also on 64-bit Windows
     appIcon.on('double-click', toggleMainWindow);
+    break;
+  default:
+    // impossible case to satisfy Linters
 }
 
 

--- a/src/main/features/core/tray.js
+++ b/src/main/features/core/tray.js
@@ -40,43 +40,38 @@ const setContextMenu = () => {
 setContextMenu();
 
 
-/**
- * Toggle the main window (on tray click).
- * If in background, bring to foreground.
- */
+// Tray icon toggle action (windows, linux)
 function toggleMainWindow() {
   // the mainWindow variable will be GC'd
   // we must find the window ourselves
   const win = WindowManager.getAll('main')[0];
 
-  if (process.platform === 'darwin') { // OS-X - Not tested!
-    if (!win.isVisible()) {
-      // Show
-      win.setSkipTaskbar(false);
-      win.show();
-    } else {
-      // Hide to tray, if configured
-      if (Settings.get('minToTray', true)) {
-        win.hide();
-      }
-    }
-  } else { // Windows, Linux
-    if (win.isMinimized()) {
-      win.setSkipTaskbar(false);
-      win.restore();
-    } else {
-      // Hide to tray, if configured
-      if (Settings.get('minToTray', true)) {
-        win.minimize();
-        win.setSkipTaskbar(true);
-      }
+  if (win.isMinimized()) {
+    win.setSkipTaskbar(false);
+    win.show();
+  } else {
+    // Hide to tray, if configured
+    if (Settings.get('minToTray', true)) {
+      win.minimize();
+      win.setSkipTaskbar(true);
     }
   }
 }
 
 appIcon.setToolTip('Google Play Music');
-// appIcon.on('double-click', toggleMainWindow);
-appIcon.on('click', toggleMainWindow);
+
+switch (process.platform) {
+  case 'darwin': // actually means OS-X
+    // No toggle action, use the context menu.
+    break;
+  case 'linux':
+  case 'freebsd': // <- for the hipsters
+  case 'sunos':   // <- in case someone runs this in a museum
+    appIcon.on('click', toggleMainWindow);
+    break;
+  case 'win32': // <- it's win32 also on 64-bit Windows
+    appIcon.on('double-click', toggleMainWindow);
+}
 
 
 // DEV: Keep the icon in the global scope or it gets garbage collected........

--- a/src/main/features/core/tray.js
+++ b/src/main/features/core/tray.js
@@ -61,28 +61,9 @@ function toggleMainWindow() {
       }
     }
   } else { // Windows, Linux
-    const wasMinimized = win.isMinimized();
-
-    if (wasMinimized || !win.isFocused()) {
+    if (win.isMinimized()) {
       win.setSkipTaskbar(false);
-      win.show();
-
-      win.focus(); // if not minimized, try to focus it
-
-      if (!wasMinimized && !win.isFocused()) {
-        // Failed to focus the window !
-
-        // The window is in a weird glitch state caused
-        // by "closing" it with the cross button
-
-        // Since we can't give it focus, assume it's in the
-        // foreground and user actually wanted to hide it.
-        if (Settings.get('minToTray', true)) {
-          win.minimize();
-          win.setSkipTaskbar(true);
-        }
-      }
-
+      win.restore();
     } else {
       // Hide to tray, if configured
       if (Settings.get('minToTray', true)) {
@@ -94,10 +75,8 @@ function toggleMainWindow() {
 }
 
 appIcon.setToolTip('Google Play Music');
-appIcon.on('click', toggleMainWindow);
-
-/* does not work if the 'click' handler is present */
 //appIcon.on('double-click', toggleMainWindow);
+appIcon.on('click', toggleMainWindow);
 
 
 // DEV: Keep the icon in the global scope or it gets garbage collected........


### PR DESCRIPTION
This is the click-toggle part of #278.

I tried keeping both 'click' and 'double-click' handlers, but it didn't work, so only the 'click' handler is currently enabled. Maybe it could be configurable, but 'click' feels more comfortable (imo).

There is one glitch (which however **is not new**). Please see the comments.<br>
I've tried some hacks and nothing worked, so we can probably just let it be. It's not that bad.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/marshallofsound/google-play-music-desktop-player-unofficial-/297)
<!-- Reviewable:end -->
