### PR TITLE
Pretty print JSON in the config directory

### DIFF
--- a/src/main/utils/PlaybackAPI.js
+++ b/src/main/utils/PlaybackAPI.js
@@ -58,7 +58,7 @@ class PlaybackAPI {
 
   _save() {
     if (Settings.get('enableJSONApi', true)) {
-      fs.writeFileSync(this.PATH, JSON.stringify(this.data));
+      fs.writeFileSync(this.PATH, JSON.stringify(this.data, null, 4));
     }
   }
 

--- a/src/main/utils/Settings.js
+++ b/src/main/utils/Settings.js
@@ -51,7 +51,7 @@ class Settings {
     // During some save events (like resize) we need to queue the disk writes
     // so that we don't blast the disk every millisecond
     if ((now - this.lastSync > 250 || force)) {
-      fs.writeFileSync(this.PATH, JSON.stringify(this.data));
+      fs.writeFileSync(this.PATH, JSON.stringify(this.data, null, 4));
     } else {
       if (this.saving) clearTimeout(this.saving);
       this.saving = setTimeout(this._save.bind(this), 275);


### PR DESCRIPTION
This PR formats the JSON so it's easier to read and edit manually.

Example:

```
{
    "playing": true,
    "song": {
        "title": "Far From Over",
        "artist": "Kamaya Painters",
        "album": "In Search Of Sunrise 1",
        "albumArt": "https://lh5.ggpht.com/7ZrB94FDzhPWzO0Ine_JS41VG9qjUe_ZHaX9lfxj0uujO5fac5yyrZwKB_EEKouk2DivqE_NaQ=s90-c-e100"
    },
    "time": {
        "current": 27311,
        "total": 354000
    },
    "songLyrics": null
}
```

Same for the settings file (which is hidden—starts with a dot, why??).