### PR TITLE
Fix #306 and restore original color on profile popup buttons

### DIFF
--- a/src/inject/GPMInject/interface/customUI.js
+++ b/src/inject/GPMInject/interface/customUI.js
@@ -21,11 +21,11 @@ const style = (elementSelector, styleObject) => {
   });
 };
 
-const cssRule = (css) => {
-  const style = document.createElement('style');
-  style.type = 'text/css';
-  style.appendChild(document.createTextNode(css));
-  document.head.appendChild(style);
+const cssRule = (styles) => {
+  const tag = document.createElement('style');
+  tag.type = 'text/css';
+  tag.appendChild(document.createTextNode(styles));
+  document.head.appendChild(tag);
 };
 
 window.wait(() => {

--- a/src/inject/GPMInject/interface/customUI.js
+++ b/src/inject/GPMInject/interface/customUI.js
@@ -21,7 +21,17 @@ const style = (elementSelector, styleObject) => {
   });
 };
 
+const cssRule = (css) => {
+  const style = document.createElement('style');
+  style.type = 'text/css';
+  style.appendChild(document.createTextNode(css));
+  document.head.appendChild(style);
+};
+
 window.wait(() => {
+  // Restore original text color on buttons in the Profile dialog (dark theme sets it to white).
+  cssRule('.gmusic-theme .material div.gb_ob a.gb_Ca.gb_nb {color: #666 !important}');
+
   // Top left account control buttons
   hide('#material-one-right #gb > div > div > div:not(:last-child)');
   style('#material-one-right #gb > div > div > div:last-child',


### PR DESCRIPTION
Ideally the theme should take care of this, but for now *grey on white* is better than *white on white*.

![xxx](https://cloud.githubusercontent.com/assets/2041118/13576240/035077ea-e48d-11e5-86ed-f3b5ced34811.png)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/marshallofsound/google-play-music-desktop-player-unofficial-/343)
<!-- Reviewable:end -->
