### PR TITLE
Added an injected Back button w/ auto-hide

### DIFF
--- a/src/inject/GPMInject/interface/customUI.js
+++ b/src/inject/GPMInject/interface/customUI.js
@@ -21,6 +21,13 @@ const style = (elementSelector, styleObject) => {
   });
 };
 
+const cssRule = (styles) => {
+  const tag = document.createElement('style');
+  tag.type = 'text/css';
+  tag.appendChild(document.createTextNode(styles));
+  document.head.appendChild(tag);
+};
+
 window.wait(() => {
   // Top left account control buttons
   hide('#material-one-right #gb > div > div > div:not(:last-child)');
@@ -58,24 +65,32 @@ window.wait(() => {
   const back = document.createElement('paper-icon-button');
   back.setAttribute('onclick', 'history.back()');
   back.setAttribute('icon', 'arrow-back');
-  back.setAttribute('id', 'back-button');
+  back.setAttribute('id', 'backButton');
   back.setAttribute('class', 'x-scope paper-icon-button-0');
   document.querySelector('#material-one-middle > sj-search-box').insertBefore(back, null);
 
-  style('#back-button', {
-      'position': 'absolute',
-      'right': '3px',
-      'top': '1px',
-      'width': '46px',
-      'height': '46px',
-      'opacity': '0',
-      'transition': 'opacity 0.2s ease-in-out'
+  style('#backButton', {
+    position: 'absolute',
+    right: '3px',
+    top: '1px',
+    width: '46px',
+    height: '46px',
+    opacity: '0',
+    transition: 'opacity 0.2s ease-in-out',
   });
+
+  // Make sure the clearSearch button is above the arrow
+  style('sj-search-box #clearButton', { 'z-index': 10 });
+
+  // Hide icon if search box has query
+  cssRule('sj-search-box[has-query] #backButton {opacity: 0 !important}');
 
   // Ideally we should listen for the URL change
   // 'hashchange' does not seem to work :(
   setInterval(() => {
-    if (location.href.indexOf('https://play.google.com/music/listen#/now') === 0) {
+    const homePage = (location.href.indexOf('https://play.google.com/music/listen#/now') === 0);
+    const searching = (document.querySelector('sj-search-box input').value !== '');
+    if (homePage || searching) {
       back.style.opacity = 0;
     } else {
       back.style.opacity = 1;

--- a/src/inject/GPMInject/interface/customUI.js
+++ b/src/inject/GPMInject/interface/customUI.js
@@ -63,7 +63,7 @@ window.wait(() => {
 
   // Back button
   const back = document.createElement('paper-icon-button');
-  back.setAttribute('onclick', 'history.back()');
+  back.addEventListener('click', () => history.back());
   back.setAttribute('icon', 'arrow-back');
   back.setAttribute('id', 'backButton');
   back.setAttribute('class', 'x-scope paper-icon-button-0');

--- a/src/inject/GPMInject/interface/customUI.js
+++ b/src/inject/GPMInject/interface/customUI.js
@@ -53,4 +53,32 @@ window.wait(() => {
     return false;
   });
   document.querySelectorAll('.nav-section.material')[0].insertBefore(dSettings, document.querySelectorAll('.nav-section.material > a')[2]); // eslint-disable-line
+
+  // Back button
+  const back = document.createElement('paper-icon-button');
+  back.setAttribute('onclick', 'history.back()');
+  back.setAttribute('icon', 'arrow-back');
+  back.setAttribute('id', 'back-button');
+  back.setAttribute('class', 'x-scope paper-icon-button-0');
+  document.querySelector('#material-one-middle > sj-search-box').insertBefore(back, null);
+
+  style('#back-button', {
+      'position': 'absolute',
+      'right': '3px',
+      'top': '1px',
+      'width': '46px',
+      'height': '46px',
+      'opacity': '0',
+      'transition': 'opacity 0.2s ease-in-out'
+  });
+
+  // Ideally we should listen for the URL change
+  // 'hashchange' does not seem to work :(
+  setInterval(() => {
+    if (location.href.indexOf('https://play.google.com/music/listen#/now') === 0) {
+      back.style.opacity = 0;
+    } else {
+      back.style.opacity = 1;
+    }
+  }, 250);
 });


### PR DESCRIPTION
This solves #217 and it's dupes.

I've added a back button, forward button doesn't seem to be necessary (I've never needed it, anyway).

The button auto-hides on the "Listen Now" page, which is the initial landing page.

![screenshot_2016-03-07_21-00-09](https://cloud.githubusercontent.com/assets/2041118/13581614/06691eee-e4a8-11e5-87d4-20d5baf4dd66.png)

![screenshot_2016-03-07_21-00-42](https://cloud.githubusercontent.com/assets/2041118/13581617/091620ba-e4a8-11e5-872d-6db4f5263215.png)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/marshallofsound/google-play-music-desktop-player-unofficial-/348)
<!-- Reviewable:end -->
