### PR TITLE
Settings toggle for native window decorations

### DIFF
--- a/src/assets/less/main_window.less
+++ b/src/assets/less/main_window.less
@@ -13,7 +13,7 @@ html, body {
 }
 
 // Only use the custom borders on windows
-.darwin, .linux, .freebsd, .sunos {
+.native-frame {
   .window-border {
     border: 0;
     > header {

--- a/src/assets/less/main_window.less
+++ b/src/assets/less/main_window.less
@@ -12,7 +12,7 @@ html, body {
   padding: 0;
 }
 
-// Only use the custom borders on windows
+// Hide custom frame when native frame is used
 .native-frame {
   .window-border {
     border: 0;

--- a/src/inject/generic.js
+++ b/src/inject/generic.js
@@ -15,6 +15,8 @@ const waitForBody = setInterval(() => {
     }
     require('electron').remote.getCurrentWindow().show();
 
+    document.body.classList.toggle('native-frame', Settings.get('nativeFrame'));
+
     document.addEventListener('dragover', (event) => {
       event.preventDefault();
       return false;

--- a/src/inject/settings/general.js
+++ b/src/inject/settings/general.js
@@ -20,3 +20,16 @@ if (Settings.get('speechRecognition', false)) {
 } else {
   $('#voice-controls').removeAttr('checked');
 }
+
+$('#native-frame').change((e) => {
+  Emitter.fire('settings:set', {
+    key: 'nativeFrame',
+    value: $(e.currentTarget).is(':checked'),
+  });
+});
+
+if (Settings.get('nativeFrame')) {
+  $('#native-frame').attr('checked', true);
+} else {
+  $('#native-frame').removeAttr('checked');
+}

--- a/src/main/configureBrowser.js
+++ b/src/main/configureBrowser.js
@@ -15,7 +15,7 @@ export default () => {
     x: Settings.get('X'),
     y: Settings.get('Y'),
     show: false,
-    frame: (process.platform !== 'win32'),
+    frame: Settings.get('nativeFrame'),
     icon: path.resolve(`${__dirname}/../assets/img/main.png`),
     title: 'Nucleus Player',
     nodeIntegration: true,

--- a/src/main/features/core/desktopSettings.js
+++ b/src/main/features/core/desktopSettings.js
@@ -8,8 +8,8 @@ export const showDesktopSettings = () => {
   }
   const desktopSettings = new BrowserWindow({
     width: 800,
-    height: 480,
-    frame: (process.platform !== 'win32'),
+    height: 540,
+    frame: Settings.get('nativeFrame'),
     show: false,
     nodeIntegration: true,
     icon: path.resolve(`${__dirname}/../../../assets/img/main.png`),

--- a/src/main/features/core/lastFM.js
+++ b/src/main/features/core/lastFM.js
@@ -29,7 +29,7 @@ const authLastFMToken = (token) => {
       height: 720,
       center: true,
       show: false,
-      frame: (process.platform !== 'win32'),
+      frame: Settings.get('nativeFrame'),
       nodeIntegration: false,
       icon: path.resolve(`${__dirname}/../../../assets/img/main.png`),
       title: 'Last.FM',

--- a/src/main/utils/Settings.js
+++ b/src/main/utils/Settings.js
@@ -45,7 +45,7 @@ class Settings {
 
   _load() {
     const userSettings = JSON.parse(fs.readFileSync(this.PATH, 'utf8'));
-    this.data = _.defaults(userSettings, initalSettings);
+    this.data = _.extend({}, initalSettings, userSettings);
   }
 
   _save(force) {

--- a/src/main/utils/Settings.js
+++ b/src/main/utils/Settings.js
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import _ from 'lodash';
 import mkdirp from 'mkdirp';
 import initalSettings from './initialSettings';
 
@@ -43,7 +44,8 @@ class Settings {
   }
 
   _load() {
-    this.data = JSON.parse(fs.readFileSync(this.PATH, 'utf8'));
+    const userSettings = JSON.parse(fs.readFileSync(this.PATH, 'utf8'));
+    this.data = _.defaults(userSettings, initalSettings);
   }
 
   _save(force) {

--- a/src/main/utils/initialSettings.js
+++ b/src/main/utils/initialSettings.js
@@ -1,4 +1,5 @@
 export default {
   themeColor: '#2196F3',
   enableJSONApi: true,
+  nativeFrame: (process.platform !== 'win32'),
 };

--- a/src/public_html/desktop_settings.html
+++ b/src/public_html/desktop_settings.html
@@ -75,6 +75,10 @@
                 <input type="checkbox" class="filled-in" id="playback-api" />
                 <label for="playback-api">Enable Playback API <i>This allows other applications to interface with GPMDP</i></label>
               </p>
+              <p>
+                <input type="checkbox" class="filled-in" id="native-frame" />
+                <label for="native-frame">Use system window decorations <i>Requires restart.</i></label>
+              </p>
             </div>
           </div>
           <div id="mini" class="col s12 settings-box">

--- a/src/public_html/desktop_settings.html
+++ b/src/public_html/desktop_settings.html
@@ -77,7 +77,7 @@
               </p>
               <p>
                 <input type="checkbox" class="filled-in" id="native-frame" />
-                <label for="native-frame">Use system window decorations <i>Requires restart.</i></label>
+                <label for="native-frame">Use system window borders <i>Requires restart.</i></label>
               </p>
             </div>
           </div>


### PR DESCRIPTION
Yep, it's me again, with another PR that will no doubt fail thanks to Travis.

- The window decorations are now configurable.
- By default nothing should change, but there's a toggle in the settings for the custom frame.
- The settings window is slightly higher (yet again), it didn't fit

![screenshot_2016-03-08_20-33-32](https://cloud.githubusercontent.com/assets/2041118/13613612/2c96923e-e56d-11e5-982f-c960a7555075.png)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/marshallofsound/google-play-music-desktop-player-unofficial-/386)
<!-- Reviewable:end -->
