### PR TITLE
Fixed mini-player on i3 (Linux)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@ import EmitterClass from './main/utils/Emitter';
 import SettingsClass from './main/utils/Settings';
 import WindowManagerClass from './main/utils/WindowManager';
 import PlaybackAPIClass from './main/utils/PlaybackAPI';
+import I3IpcHelperClass from './main/utils/I3IpcHelper';
 
 import handleStartupEvent from './squirrel';
 
@@ -41,6 +42,7 @@ import handleStartupEvent from './squirrel';
   global.WindowManager = new WindowManagerClass();
   global.Settings = new SettingsClass();
   global.PlaybackAPI = new PlaybackAPIClass();
+  global.I3IpcHelper = new I3IpcHelperClass();
 
   // Quit when all windows are closed.
   app.on('window-all-closed', () => {

--- a/src/index.js
+++ b/src/index.js
@@ -42,7 +42,6 @@ import handleStartupEvent from './squirrel';
   global.WindowManager = new WindowManagerClass();
   global.Settings = new SettingsClass();
   global.PlaybackAPI = new PlaybackAPIClass();
-  global.I3IpcHelper = new I3IpcHelperClass();
 
   // Quit when all windows are closed.
   app.on('window-all-closed', () => {
@@ -84,6 +83,10 @@ import handleStartupEvent from './squirrel';
       mainWindow = null;
       PlaybackAPI.reset();
     });
+
+    // setup i3 listener
+    const I3IpcHelper = new I3IpcHelperClass();
+    I3IpcHelper.setupEventListener();
   });
 
   app.on('before-quit', () => {

--- a/src/inject/GPMInject/interface/mini.js
+++ b/src/inject/GPMInject/interface/mini.js
@@ -7,12 +7,15 @@ const MINI_SIZE = 310;
 let mini = false;
 let oldSize;
 
+const I3IpcHelper = remote.getGlobal('I3IpcHelper');
+
 window.wait(() => {
   if (Settings.get('miniAlwaysShowSongInfo', false)) {
     document.body.setAttribute('controls', 'controls');
   }
 
   window.GPM.mini.on('enable', () => {
+    I3IpcHelper.setFloating(true);
     Emitter.fire('mini', { state: true });
     oldSize = remote.getCurrentWindow().getSize();
     mainWindow.setSize(MINI_SIZE, MINI_SIZE);
@@ -24,6 +27,7 @@ window.wait(() => {
   });
 
   window.GPM.mini.on('disable', () => {
+    I3IpcHelper.setFloating(false);
     Emitter.fire('mini', { state: false });
     // DEV: Set max size to be massive
     //      Same reason as specified in Electron src

--- a/src/inject/GPMInject/interface/mini.js
+++ b/src/inject/GPMInject/interface/mini.js
@@ -7,15 +7,12 @@ const MINI_SIZE = 310;
 let mini = false;
 let oldSize;
 
-const I3IpcHelper = remote.getGlobal('I3IpcHelper');
-
 window.wait(() => {
   if (Settings.get('miniAlwaysShowSongInfo', false)) {
     document.body.setAttribute('controls', 'controls');
   }
 
   window.GPM.mini.on('enable', () => {
-    I3IpcHelper.setFloating(true);
     Emitter.fire('mini', { state: true });
     oldSize = remote.getCurrentWindow().getSize();
     mainWindow.setSize(MINI_SIZE, MINI_SIZE);
@@ -27,7 +24,6 @@ window.wait(() => {
   });
 
   window.GPM.mini.on('disable', () => {
-    I3IpcHelper.setFloating(false);
     Emitter.fire('mini', { state: false });
     // DEV: Set max size to be massive
     //      Same reason as specified in Electron src

--- a/src/main/utils/I3IpcHelper.js
+++ b/src/main/utils/I3IpcHelper.js
@@ -8,7 +8,7 @@ class I3IpcHelper {
 
   _hasI3Msg(callback) {
     if (this.isI3()) {
-      exec('command -v i3-msg', error => {
+      exec('command -v i3-msg', (error) => {
         // we'll get a non 0 exit code if the command doesn't exist
         // this should work on any POSIX compatible shell
         callback(error === null);

--- a/src/main/utils/I3IpcHelper.js
+++ b/src/main/utils/I3IpcHelper.js
@@ -36,6 +36,12 @@ class I3IpcHelper {
     });
   }
 
+  setupEventListener() {
+    Emitter.on('mini', (event, eventArguments) => {
+      this.setFloating(eventArguments.state);
+    });
+  }
+
 }
 
 export default I3IpcHelper;

--- a/src/main/utils/I3IpcHelper.js
+++ b/src/main/utils/I3IpcHelper.js
@@ -1,0 +1,40 @@
+import { exec } from 'child_process';
+
+class I3IpcHelper {
+
+  isI3() {
+    return WindowManager.getWindowManagerName() === 'i3';
+  }
+
+  _hasI3Msg(callback) {
+    if(this.isI3()) {
+      exec('command -v i3-msg', error => {
+        //we'll get a non 0 exit code if the command doesn't exist this should work on any POSIX compatible shell
+        callback(error === null);
+      });
+    }
+    return false;
+  }
+
+  _getWindowTitleRegex() {
+    const title = WindowManager.get(global.mainWindowID).getTitle();
+    return '^' + title + '$';
+  }
+
+  _escapeShellArg(str) {
+    return str.replace(/'/, "\\'").replace(/"/, "\\\"");
+  }
+
+  setFloating(mode) {
+    this._hasI3Msg(hasMsg => {
+      if(hasMsg) {
+        const title = this._escapeShellArg(this._getWindowTitleRegex());
+        const floatingMode = mode ? 'enable' : 'disable';
+        exec(`i3-msg '[title="${title}"] floating ${floatingMode}'`, () => {});
+      }
+    });
+  }
+
+}
+
+export default I3IpcHelper;

--- a/src/main/utils/I3IpcHelper.js
+++ b/src/main/utils/I3IpcHelper.js
@@ -7,9 +7,10 @@ class I3IpcHelper {
   }
 
   _hasI3Msg(callback) {
-    if(this.isI3()) {
+    if (this.isI3()) {
       exec('command -v i3-msg', error => {
-        //we'll get a non 0 exit code if the command doesn't exist this should work on any POSIX compatible shell
+        // we'll get a non 0 exit code if the command doesn't exist
+        // this should work on any POSIX compatible shell
         callback(error === null);
       });
     }
@@ -22,12 +23,12 @@ class I3IpcHelper {
   }
 
   _escapeShellArg(str) {
-    return str.replace(/'/, "\\'").replace(/"/, "\\\"");
+    return str.replace(/'/g, "\\'").replace(/"/g, '\\\"');
   }
 
   setFloating(mode) {
     this._hasI3Msg(hasMsg => {
-      if(hasMsg) {
+      if (hasMsg) {
         const title = this._escapeShellArg(this._getWindowTitleRegex());
         const floatingMode = mode ? 'enable' : 'disable';
         exec(`i3-msg '[title="${title}"] floating ${floatingMode}'`, () => {});

--- a/src/main/utils/WindowManager.js
+++ b/src/main/utils/WindowManager.js
@@ -67,10 +67,10 @@ class WindowManager {
   }
 
   getWindowManagerName() {
-    if(process.platform === 'linux') {
+    if (process.platform === 'linux') {
       return process.env.XDG_CURRENT_DESKTOP;
     }
-    return 'unknown';
+    return undefined;
   }
 
 }

--- a/src/main/utils/WindowManager.js
+++ b/src/main/utils/WindowManager.js
@@ -65,6 +65,14 @@ class WindowManager {
       this.windows[windowID].close();
     }
   }
+
+  getWindowManagerName() {
+    if(process.platform === 'linux') {
+      return process.env.XDG_CURRENT_DESKTOP;
+    }
+    return 'unknown';
+  }
+
 }
 
 export default WindowManager;


### PR DESCRIPTION
I also ran into the issue discussed in this thread: https://github.com/MarshallOfSound/Google-Play-Music-Desktop-Player-UNOFFICIAL-/issues/270

This pull request makes sure the mini-player works in i3 by using the i3 IPC bridge and sending the window into floating mode.

* [x] Fix linting issues
* [x] Add global flag to RegExp