### PR TITLE
Use electron's `userData` for config files

### DIFF
--- a/src/main/utils/PlaybackAPI.js
+++ b/src/main/utils/PlaybackAPI.js
@@ -2,19 +2,24 @@ import fs from 'fs';
 import mkdirp from 'mkdirp';
 
 const os = require('os');
+const app = require('app');
 
 const environment = process.env;
 
 class PlaybackAPI {
   constructor() {
-    const DIR = (environment.APPDATA ||
+    const DIR = app.getPath('userData');
+    this.PATH = `${DIR}/playback.json`;
+    const OLD_DIR = (environment.APPDATA ||
       (process.platform === 'darwin' ? environment.HOME + '/Library/Preferences' : os.homedir())) +
       '/GPMDP_STORE';
-    this.PATH = `${DIR}/playback.json`;
+    const OLD_PATH = `${OLD_DIR}/playback.json`;
 
     this.reset();
-
-    if (!fs.existsSync(this.PATH)) {
+    if (fs.existsSync(OLD_PATH)) {
+      fs.renameSync(OLD_PATH, this.PATH);
+      fs.rmdir(OLD_DIR, function () {});
+    } else if (!fs.existsSync(this.PATH)) {
       mkdirp(DIR);
       this._save();
     }

--- a/src/main/utils/PlaybackAPI.js
+++ b/src/main/utils/PlaybackAPI.js
@@ -1,4 +1,4 @@
-import app from 'app';
+import { app } from 'electron';
 import fs from 'fs';
 import mkdirp from 'mkdirp';
 

--- a/src/main/utils/PlaybackAPI.js
+++ b/src/main/utils/PlaybackAPI.js
@@ -1,8 +1,8 @@
+import app from 'app';
 import fs from 'fs';
 import mkdirp from 'mkdirp';
 
 const os = require('os');
-const app = require('app');
 
 const environment = process.env;
 

--- a/src/main/utils/Settings.js
+++ b/src/main/utils/Settings.js
@@ -1,9 +1,9 @@
+import app from 'app';
 import fs from 'fs';
 import mkdirp from 'mkdirp';
 import initalSettings from './initialSettings';
 
 const os = require('os');
-const app = require('app');
 
 const environment = process.env;
 

--- a/src/main/utils/Settings.js
+++ b/src/main/utils/Settings.js
@@ -1,4 +1,4 @@
-import app from 'app';
+import { app } from 'electron';
 import fs from 'fs';
 import mkdirp from 'mkdirp';
 import initalSettings from './initialSettings';

--- a/src/main/utils/Settings.js
+++ b/src/main/utils/Settings.js
@@ -3,19 +3,26 @@ import mkdirp from 'mkdirp';
 import initalSettings from './initialSettings';
 
 const os = require('os');
+const app = require('app');
 
 const environment = process.env;
 
 class Settings {
   constructor(jsonPrefix, wipeOldData) {
-    const DIR = (environment.APPDATA ||
+    const DIR = app.getPath('userData');
+    this.PATH = `${DIR}/${(jsonPrefix || '')}.settings.json`;
+    const OLD_DIR = (environment.APPDATA ||
       (process.platform === 'darwin' ? environment.HOME + '/Library/Preferences' : os.homedir())) +
       '/GPMDP_STORE';
-    this.PATH = `${DIR}/${(jsonPrefix || '')}.settings.json`;
+    const OLD_PATH = `${OLD_DIR}/${(jsonPrefix || '')}.settings.json`;
     this.data = initalSettings;
     this.lastSync = 0;
 
     if (fs.existsSync(this.PATH) && !wipeOldData) {
+      this._load();
+    } else if (fs.existsSync(OLD_PATH)) {
+      fs.renameSync(OLD_PATH, this.PATH);
+      fs.rmdir(OLD_DIR, function () {});
       this._load();
     } else {
       mkdirp.sync(DIR);


### PR DESCRIPTION
If a file isn't present in `userData`, look for it in its old spot. If
it's in its old spot, move it to `userData` and try to delete the old
directory.

Fixes #267. Closes #287.