### PR TITLE
Fixed mini player controls being off-screen when the menu was expanded

### DIFF
--- a/src/inject/GPMInject/interface/mini.js
+++ b/src/inject/GPMInject/interface/mini.js
@@ -21,6 +21,11 @@ window.wait(() => {
     remote.getCurrentWebContents().setZoomFactor(1);
     remote.getCurrentWindow().setAlwaysOnTop(Settings.get('miniAlwaysOnTop', false));
     mini = true;
+    // close menu if expanded
+    const closeBtn = document.getElementById('left-nav-close-button');
+    if (closeBtn !== null) {
+      closeBtn.click();
+    }
   });
 
   window.GPM.mini.on('disable', () => {


### PR DESCRIPTION
This should fix issue https://github.com/MarshallOfSound/Google-Play-Music-Desktop-Player-UNOFFICIAL-/issues/401

The problem was that the menu would push the controls off screen when it was expanded before one triggered the mini player mode. This PR closes the menu when entering mini mode therefore fixing the issue.