### PR TITLE
Persist the size of the mini-player and store it independently of the main window.

### DIFF
--- a/src/inject/GPMInject/interface/mini.js
+++ b/src/inject/GPMInject/interface/mini.js
@@ -5,7 +5,6 @@ const webContents = mainWindow.webContents;
 const MINI_SIZE = 310;
 
 let mini = false;
-let oldSize;
 
 window.wait(() => {
   if (Settings.get('miniAlwaysShowSongInfo', false)) {
@@ -14,8 +13,13 @@ window.wait(() => {
 
   window.GPM.mini.on('enable', () => {
     Emitter.fire('mini', { state: true });
-    oldSize = remote.getCurrentWindow().getSize();
-    mainWindow.setSize(MINI_SIZE, MINI_SIZE);
+
+	// Restore the mini size/position from settings, otherwise use default size and regular position.
+    const miniSize = Settings.get('mini-size', [MINI_SIZE, MINI_SIZE]);
+    const miniPosition = Settings.get('mini-position', mainWindow.getPosition());
+    mainWindow.setSize(...miniSize);
+    mainWindow.setPosition(...miniPosition);
+
     mainWindow.setMaximumSize(MINI_SIZE, MINI_SIZE);
     webContents.executeJavaScript('document.body.setAttribute("mini", "mini")');
     remote.getCurrentWebContents().setZoomFactor(1);
@@ -29,7 +33,13 @@ window.wait(() => {
     //      Same reason as specified in Electron src
     //        --> https://github.com/atom/electron/blob/master/atom/browser/native_window_views.cc
     mainWindow.setMaximumSize(99999999, 999999999);
-    mainWindow.setSize(...oldSize);
+
+    // Restore the regular size/position from settings.
+    const regularSize = Settings.get('size');
+    const regularPosition = Settings.get('position');
+    mainWindow.setSize(...regularSize);
+    mainWindow.setPosition(...regularPosition);
+
     webContents.executeJavaScript('document.body.removeAttribute("mini", "mini")');
     remote.getCurrentWebContents().setZoomFactor(1);
     remote.getCurrentWindow().setAlwaysOnTop(false);

--- a/src/main/features/core/persistAppState.js
+++ b/src/main/features/core/persistAppState.js
@@ -13,6 +13,10 @@ const _save = () => {
     Settings.set('position', mainWindow.getPosition());
     Settings.set('size', mainWindow.getSize());
   } else {
+    Settings.set('mini-position', mainWindow.getPosition());
+    Settings.set('mini-size', mainWindow.getSize());
+
+    // Keep the mini-player square.
     const dimension = Math.max(...mainWindow.getSize());
     if (resizeTimer) clearTimeout(resizeTimer);
     resizeTimer = setTimeout(() => mainWindow.setSize(dimension, dimension), 100);


### PR DESCRIPTION
Switching between the mini-player and the regular window get tedious, especially when you prefer the mini player to be at the bottom of the screen. Issue #232 already tracks this.

This PR tracks the positions/sizes of the mini-player separately from the regular window and persists both across closes of the app.

P.S. Please review this carefully, I haven't done any dev against electron before.