### PR TITLE
Ubuntu gnome media keys play/next/previous implementation.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -4,7 +4,7 @@ machine:
 
 dependencies:
   pre:
-    - sudo apt-get update; sudo apt-get install rpm fakeroot dpkg
+    - sudo apt-get update; sudo apt-get install rpm fakeroot dpkg libdbus-1-dev libglib2.0-dev
     - npm i -g npm
   cache_directories:
     - "~/.electron"

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "sinon-chai": "^2.8.0"
   },
   "optionalDependencies": {
+    "dbus": "^0.2.17",
     "electron-installer-debian": "^0.2.0",
     "electron-installer-redhat": "^0.2.0",
     "ll-keyboard-hook-win": "^2.0.1"

--- a/src/main/features/linux/index.js
+++ b/src/main/features/linux/index.js
@@ -1,0 +1,1 @@
+import './mediaKeysDBus.js';

--- a/src/main/features/linux/mediaKeysDBus.js
+++ b/src/main/features/linux/mediaKeysDBus.js
@@ -1,0 +1,24 @@
+import DBus from 'dbus';
+
+try {
+  const dbus = new DBus();
+  const session = dbus.getBus('session');
+
+  session.getInterface('org.gnome.SettingsDaemon', '/org/gnome/SettingsDaemon/MediaKeys',
+  'org.gnome.SettingsDaemon.MediaKeys', (err, iface) => {
+    if (!err) {
+      iface.on('MediaPlayerKeyPressed', (n, keyName) => {
+        switch (keyName) {
+          case 'Next': Emitter.sendToGooglePlayMusic('playback:nextTrack'); return;
+          case 'Previous': Emitter.sendToGooglePlayMusic('playback:previousTrack'); return;
+          case 'Play': Emitter.sendToGooglePlayMusic('playback:playPause'); return;
+          case 'Stop': Emitter.sendToGooglePlayMusic('playback:stop'); return;
+          default: return;
+        }
+        iface.GrabMediaPlayerKeys(0, 'org.gnome.SettingsDaemon.MediaKeys'); // eslint-disable-line
+      });
+    }
+  });
+} catch (e) {
+  // do nothing.
+}


### PR DESCRIPTION
This should fix the standard media keys on Ubuntu, uses DBus to capture the events coming from gnome without causing gnome to surrender the global listener. 

Partially fixes #298