### PR TITLE
Fix bug in media player keys ubuntu

### DIFF
--- a/src/main/features/linux/mediaKeysDBus.js
+++ b/src/main/features/linux/mediaKeysDBus.js
@@ -15,8 +15,8 @@ try {
           case 'Stop': Emitter.sendToGooglePlayMusic('playback:stop'); return;
           default: return;
         }
-        iface.GrabMediaPlayerKeys(0, 'org.gnome.SettingsDaemon.MediaKeys'); // eslint-disable-line
       });
+      iface.GrabMediaPlayerKeys(0, 'org.gnome.SettingsDaemon.MediaKeys'); // eslint-disable-line
     }
   });
 } catch (e) {


### PR DESCRIPTION
I don't know when this happened, but this fixes the bug of them not working in the master branch.