### PR TITLE
Issue #748: Make popup dismissable

### DIFF
--- a/src/inject/GPMInject/interface/errorHandler.js
+++ b/src/inject/GPMInject/interface/errorHandler.js
@@ -4,6 +4,7 @@ Emitter.on('error', (event, details) => {
   const toast = document.createElement('paper-toast');
   toast.setAttribute('text', `An uncaught error has occurred inside GPMDP.`);
   toast.duration = 0;
+  toast.noCancelOnOutsideClick = false;
   const issueButton = document.createElement('a');
   issueButton.innerHTML = 'Click here to report this as an issue on GitHub';
   issueButton.style.color = '#E53935';


### PR DESCRIPTION
Based on polymer docs for paper-toast (https://elements.polymer-project.org/elements/paper-toast#property-noCancelOnOutsideClick) it seems this should make the popup dismissable by clicking outside of the element.

Unsure of how to test this error handler locally, so I couldn't verify.