### PR TITLE
Add needed apostrophe

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -193,7 +193,7 @@
       <div class="row">
         <div class="col l6 s12">
           <h5 class="white-text">About the Author</h5>
-          <p class="grey-text text-lighten-4">I am a University student based in Melbourne, AU but originally from Auckland, NZ.  I love programming in my spare time and think its great giving back to the community through Open Source projects such as this.</p>
+          <p class="grey-text text-lighten-4">I am a University student based in Melbourne, AU but originally from Auckland, NZ.  I love programming in my spare time and think it's great giving back to the community through Open Source projects such as this.</p>
 
 
         </div>


### PR DESCRIPTION
"it's" as in "it is" needs an apostrophe, since it's a contraction.