### PR TITLE
Expose package:linux:32 and package:linux:64

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "make:win": "gulp make:win && npm run postinstall",
     "package:darwin": "gulp package:darwin",
     "package:linux": "gulp package:linux",
+    "package:linux:32": "gulp package:linux:32",
+    "package:linux:64": "gulp package:linux:64",
     "package:win": "gulp package:win && npm run postinstall",
     "postinstall": "node vendor/rebuild.js --instant",
     "test": "npm run lint",


### PR DESCRIPTION
Having deb and rpm for different architectures is great, but it then requires that the user have those package systems installed, which is not ideal for users of distributions that don't use debs or rpms. Being able to package for different architectures would prevent that issue.

Edit: Grammar.