### PR TITLE
Add cmd-left/right history navigation on OSX

### DIFF
--- a/src/inject/GPMInject/interface/customUI.js
+++ b/src/inject/GPMInject/interface/customUI.js
@@ -189,14 +189,13 @@ function installBackButton() {
    separate keypress, which also eats the keyup event of the key it
    is modifying.
    */
-  let isHoldingCmdKey = false;
+  const holdingKeyMap = {};
 
   window.addEventListener('keydown', (e) => {
-    if (e.which === 91 || e.which === 93) {
-      isHoldingCmdKey = true;
-    }
+    holdingKeyMap[e.which] = true;
 
-    if (isHoldingCmdKey && document.activeElement.value === undefined) {
+    if ((holdingKeyMap[91] === true || holdingKeyMap[93] === true)
+      && document.activeElement.value === undefined) {
       if (e.which === 37) {
         attemptBack();
       } else if (e.which === 39) {
@@ -213,9 +212,7 @@ function installBackButton() {
       attemptForward();
     }
 
-    if (e.which === 91 || e.which === 93) {
-      isHoldingCmdKey = false;
-    }
+    holdingKeyMap[e.which] = false;
   });
 
   style('#backButton', {

--- a/src/inject/GPMInject/interface/customUI.js
+++ b/src/inject/GPMInject/interface/customUI.js
@@ -182,12 +182,39 @@ function installBackButton() {
   };
 
   backBtn.addEventListener('click', attemptBack);
+
+  /*
+   OSX has a standard of cmd+left and cmd+right for browser navigation.
+   However cmd does not show up as a modifier key, but rather as a
+   separate keypress, which also eats the keyup event of the key it
+   is modifying.
+   */
+  let isHoldingCmdKey = false;
+
+  window.addEventListener('keydown', (e) => {
+    if (e.which === 91 || e.which === 93) {
+      isHoldingCmdKey = true;
+    }
+
+    if (isHoldingCmdKey && document.activeElement.value === undefined) {
+      if (e.which === 37) {
+        attemptBack();
+      } else if (e.which === 39) {
+        attemptForward();
+      }
+    }
+  });
+
   window.addEventListener('keyup', (e) => {
     if ((e.which === 8 && document.activeElement.value === undefined)
       || (e.which === 37 && e.altKey && document.activeElement.value === undefined)) {
       attemptBack();
     } else if (e.which === 39 && e.altKey && document.activeElement.value === undefined) {
       attemptForward();
+    }
+
+    if (e.which === 91 || e.which === 93) {
+      isHoldingCmdKey = false;
     }
   });
 


### PR DESCRIPTION
Reworked based on comments on #984.