### PR TITLE
Use x86_64 architechure for fedora/redhat rpms

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -257,9 +257,14 @@ const generateGulpLinuxDistroTask = (prefix, name, arch) => {
       categories: ['AudioVideo', 'Audio'],
     };
 
+    let pkg_arch = 'i386';
+    if (arch === '64') {
+      pkg_arch = (prefix === 'rpm' ? 'x86_64' : 'amd64');
+    }
+
     tool(_.extend({}, defaults, {
       src: `dist/${packageJSON.productName}-linux-${arch === '32' ? 'ia32' : 'x64'}`,
-      arch: arch === '32' ? 'i386' : 'amd64',
+      arch: pkg_arch,
     }), (err) => {
       console.log(`${arch}bit ${prefix} package built`); // eslint-disable-line
       if (err) return done(err);


### PR DESCRIPTION
Fedora/redhat based 64-bit systems use the architechure 'x86_64'.
Packages of the architechure amd64 will be unable to be installed using
default package management tools, such as dnf or yum.

This should resolve https://github.com/MarshallOfSound/Google-Play-Music-Desktop-Player-UNOFFICIAL-/issues/883