### PR TITLE
Add support for additional hotkeys

### DIFF
--- a/src/inject/settings/hotkeys.js
+++ b/src/inject/settings/hotkeys.js
@@ -9,14 +9,35 @@ const MODIFIER_KEYS = {
   18: 'Alt',
 };
 
-const ACTION_KEYS = _.transform(_.range(26), (final, current) => {
+const ACTION_KEYS = _.transform(_.range(26), (final, current) => { // letters
   final[current + 65] = String.fromCharCode(current + 65); // eslint-disable-line
+}, _.transform(_.range(10), (final, current) => { // digits
+  final[current + 48] = current.toString(); // eslint-disable-line
+}, _.transform(_.range(12), (final, current) => { // f-keys
+  final[current + 112] = 'F' + (current + 1).toString(); // eslint-disable-line
 }, {
+  33: 'PageUp',
+  34: 'PageDown',
+  35: 'End',
+  36: 'Home',
   37: 'Left',
   38: 'Up',
   39: 'Right',
   40: 'Down',
-});
+  45: 'Insert',
+  46: 'Delete',
+  186: ';',
+  187: '=',
+  188: ',',
+  189: '-',
+  190: '.',
+  191: '/',
+  192: '`',
+  219: '[',
+  220: '\\',
+  221: ']',
+  222: '\'',
+})));
 
 const initialHotkeys = Settings.get('hotkeys', {});
 


### PR DESCRIPTION
This PR is straightforward and simple, adding support for hotkeys other than letters and arrow keys. A list of keys this PR supports is below.

- Digit keys
- Standard function keys (`F1`–`F12`)
- A variety of symbols (``-=[];',./`\``)
- `Insert`, `Delete`, `Home`, `End`, `PageUp`, `PageDown`