### PR TITLE
Remain FullScreen

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "auto-launch": "^4.0.0",
     "electron": "1.3.4",
     "electron-chromecast": "^1.0.14",
+    "electron-window-state": "^3.0.4",
     "gmusic-mini-player.js": "^2.0.6",
     "gmusic-theme.js": "^2.0.0",
     "gmusic-ui.js": "^2.1.0",

--- a/src/index.js
+++ b/src/index.js
@@ -33,6 +33,8 @@ updateShortcuts();
   // be closed automatically when the JavaScript object is garbage collected.
   let mainWindow = null;
 
+  const windowStateKeeper = require('electron-window-state');
+
   // DEV: Make the app single instance
   const shouldQuit = app.makeSingleInstance(() => {
     if (mainWindow) {
@@ -112,6 +114,12 @@ updateShortcuts();
   // initialization and is ready to create browser windows.
   app.on('ready', () => {
     mainWindow = new BrowserWindow(generateBrowserConfig());
+
+    // Set full screen if previous state was full screen
+    const mainWindowState = windowStateKeeper();
+    mainWindow.setFullScreen(mainWindowState.isFullScreen);
+    mainWindowState.manage(mainWindow);
+
     global.mainWindowID = WindowManager.add(mainWindow, 'main');
 
     const position = Settings.get('position');


### PR DESCRIPTION
Use electron-window-state package to remember full screen state of app on quit.
* If app if full screen on quit, it will start in full screen mode
* If app is NOT full screen on quit, it will start normally

Fixes [Issue#1492](https://github.com/MarshallOfSound/Google-Play-Music-Desktop-Player-UNOFFICIAL-/issues/1492)