### PR TITLE
Fixing Alarm TimePicker

### DIFF
--- a/src/renderer/ui/components/modals/AlarmModal.js
+++ b/src/renderer/ui/components/modals/AlarmModal.js
@@ -81,7 +81,7 @@ class AlarmModal extends Component {
       >
         <TimePicker
           hintText={TranslationProvider.query('button-text-click-here-to-set-alarm')}
-          textFieldStyle={{width: '100%'}}
+          fullWidth
           onChange={this.onChange}
           {...timePickerProps}
         />

--- a/src/renderer/ui/components/modals/AlarmModal.js
+++ b/src/renderer/ui/components/modals/AlarmModal.js
@@ -81,6 +81,7 @@ class AlarmModal extends Component {
       >
         <TimePicker
           hintText={TranslationProvider.query('button-text-click-here-to-set-alarm')}
+          textFieldStyle={{width: '100%'}}
           onChange={this.onChange}
           {...timePickerProps}
         />


### PR DESCRIPTION
The Alarm TimePicker text field was only 256px wide, i don't know about
other languages, but in Russian caption just didn't fit. Stretched it to
the window width, now it's looking nice.