### PR TITLE
Updated docs to reference debian package

### DIFF
--- a/docs/Installation_On_Debian.md
+++ b/docs/Installation_On_Debian.md
@@ -7,7 +7,7 @@ repository and install the app.  The commands you need to run are listeed below.
 
 ```bash
 wget -qO - https://gpmdp.xyz/bintray-public.key.asc | sudo apt-key add -
-echo "deb https://dl.bintray.com/marshallofsound/deb trusty main" | sudo tee -a /etc/apt/sources.list.d/gpmdp.list
+echo "deb https://dl.bintray.com/marshallofsound/deb debian main" | sudo tee -a /etc/apt/sources.list.d/gpmdp.list
 sudo apt-get update
 sudo apt-get install google-play-music-desktop-player
 ```


### PR DESCRIPTION
Trusty package no longer picks up updates, from what I can see