### PR TITLE
Lyrics track progress bar color is backwards from GPM UI track progress bar #1800

### DIFF
--- a/src/renderer/ui/components/generic/LyricsViewer.js
+++ b/src/renderer/ui/components/generic/LyricsViewer.js
@@ -139,8 +139,6 @@ class LyricsViewer extends Component {
 
   render() {
     const barStyle = {};
-    // would rather not hardcode for default theme but not sure if it's passed through any props
-    // dynamically get from webpage?
     barStyle.backgroundColor = 'rgb(252, 88, 37)';
 
     const progressStyle = {};

--- a/src/renderer/ui/components/generic/LyricsViewer.js
+++ b/src/renderer/ui/components/generic/LyricsViewer.js
@@ -139,15 +139,17 @@ class LyricsViewer extends Component {
 
   render() {
     const barStyle = {};
+    // would rather not hardcode for default theme but not sure if it's passed through any props
+    // dynamically get from webpage?
+    barStyle.backgroundColor = 'rgb(252, 88, 37)';
+
     const progressStyle = {};
+    progressStyle.backgroundColor = 'rgb(34, 35, 38)';
+
     if (this.props.theme) {
-      if (this.props.themeType === 'FULL') {
-        progressStyle.backgroundColor = this.props.themeColor;
-      } else {
-        barStyle.backgroundColor = this.props.themeColor;
-        progressStyle.backgroundColor = '#222326';
-      }
+      barStyle.backgroundColor = this.props.themeColor;
     }
+
     return (
       <div id="lyrics_back" className={this.state.visible ? 'vis' : ''} onClick={this.hide}>
         <div id="lyrics_container">

--- a/test/electron-renderer/ui/LyricsViewer_spec.js
+++ b/test/electron-renderer/ui/LyricsViewer_spec.js
@@ -162,12 +162,12 @@ describe('<LyricsViewer />', () => {
   it('should update the styling in dark mode', () => {
     fakeSettings('themeType', 'FULL');
     const component = mount(<LyricsViewer />, opts);
-    component.find('#lyrics_progress').props().style.backgroundColor.should.be.equal('themeColor');
+    component.find('#lyrics_bar').props().style.backgroundColor.should.be.equal('themeColor');
   });
 
   it('should reset styling when the theme is disabled', () => {
     fakeSettings('theme', false);
     const component = mount(<LyricsViewer />, opts);
-    component.find('#lyrics_progress').props().style.should.not.have.property('backgroundColor');
+    component.find('#lyrics_bar').props().style.backgroundColor.should.be.equal('rgb(252, 88, 37)');
   });
 });


### PR DESCRIPTION
Hardcoded the default color (not sure if the rgb value of default theme is passed through props). Other than that, it seems to work!

Edit: to clarify, this issue fixes #1800 