### PR TITLE
Update README with recommended node version

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ If you think you can add something cool or fix a problem, fork the repo and make
 
 Dev Requirements
 ----------------
-* Node.js (Recommend `4.4.x`)
+* Node.js (Recommend `6.3.x`)
 * NPM (3.x.x)
 
 Continuous Integration


### PR DESCRIPTION
Fixes #2038

The current readme states that Node 4.4.X is recommended for development
and yet all of the CI systems use Node 6.3.X, so I assume that the
README is out-of-date. Small PR to fix it.