### PR TITLE
Use electron.net on lastfm requests

### DIFF
--- a/src/main/features/core/lastFM.js
+++ b/src/main/features/core/lastFM.js
@@ -6,7 +6,7 @@ import { LASTFM_API_KEY, LASTFM_API_SECRET } from '../../constants';
 // hijack lastfm module to use 'electron.net' instead of 'http'
 global.GENTLY_HIJACK = {
   hijack(require) {
-    return function (moduleName) {
+    return (moduleName) => {
       let module;
 
       if (moduleName === 'http') {

--- a/src/main/features/core/lastFM.js
+++ b/src/main/features/core/lastFM.js
@@ -1,8 +1,29 @@
 import { BrowserWindow } from 'electron';
-import { LastFmNode } from 'lastfm';
 import path from 'path';
 
 import { LASTFM_API_KEY, LASTFM_API_SECRET } from '../../constants';
+
+// hijack lastfm module to use 'electron.net' instead of 'http'
+global.GENTLY_HIJACK = {
+  hijack(require) {
+    return function (moduleName) {
+      let module;
+
+      if (moduleName === 'http') {
+        module = require('electron').net;
+      } else {
+        module = require(moduleName);
+      }
+
+      return module;
+    };
+  },
+};
+
+const LastFmNode = require('lastfm').LastFmNode;
+
+// remove global variable
+delete global.GENTLY_HIJACK;
 
 const lastfm = new LastFmNode({
   api_key: LASTFM_API_KEY,


### PR DESCRIPTION
Fixes related to #921
This change monkey-patches the external `lastfm-node` library to use `electron.net` instead of node's `http` module.