### PR TITLE
Add info track keyboard shortcut

### DIFF
--- a/src/_locales/cs.json
+++ b/src/_locales/cs.json
@@ -62,6 +62,7 @@
   "playback-label-thumbs-up": "Líbí se mi",
   "playback-label-volume-down": "Snížit hlasitost",
   "playback-label-volume-up": "Zvýšit hlasitost",
+  "playback-label-info-track": "",
   "playback-os-no-track-playing": "",
 
   "settings-requires-restart": "Vyžaduje restart",

--- a/src/_locales/da.json
+++ b/src/_locales/da.json
@@ -62,6 +62,7 @@
   "playback-label-thumbs-up": "Thumbs op",
   "playback-label-volume-down": "Skru op for lydstyrken",
   "playback-label-volume-up": "Skru ned for lydstyrken",
+  "playback-label-info-track": "",
   "playback-os-no-track-playing": "",
 
   "settings-requires-restart": "Kræver genstart af GPMDP",

--- a/src/_locales/de.json
+++ b/src/_locales/de.json
@@ -62,6 +62,7 @@
   "playback-label-thumbs-up": "Daumen hoch",
   "playback-label-volume-down": "Leiser",
   "playback-label-volume-up": "Lauter",
+  "playback-label-info-track": "",
   "playback-os-no-track-playing": "Es spielt derzeit kein Titel",
 
   "settings-requires-restart": "Erfordert einen Neustart",

--- a/src/_locales/en-US.json
+++ b/src/_locales/en-US.json
@@ -62,6 +62,7 @@
   "playback-label-thumbs-up": "Thumbs Up",
   "playback-label-volume-down": "Decrease Volume",
   "playback-label-volume-up": "Increase Volume",
+  "playback-label-info-track": "Notify current track",
   "playback-os-no-track-playing": "No Track Playing",
 
   "settings-requires-restart": "Requires restart",

--- a/src/_locales/fr-FR.json
+++ b/src/_locales/fr-FR.json
@@ -62,6 +62,7 @@
   "playback-label-thumbs-up": "Voter pour",
   "playback-label-volume-down": "Baisser le volume",
   "playback-label-volume-up": "Augmenter le volume",
+  "playback-label-info-track": "",
   "playback-os-no-track-playing": "",
 
   "settings-requires-restart": "Besoin de redémarrer",

--- a/src/_locales/it.json
+++ b/src/_locales/it.json
@@ -62,6 +62,7 @@
   "playback-label-thumbs-up": "Pollice su",
   "playback-label-volume-down": "Abbassa il volume",
   "playback-label-volume-up": "Aumenta il volume",
+  "playback-label-info-track": "",
   "playback-os-no-track-playing": "Nessun brano in riproduzione",
 
   "settings-requires-restart": "Richiede riavvio",

--- a/src/_locales/ja.json
+++ b/src/_locales/ja.json
@@ -62,6 +62,7 @@
   "playback-label-thumbs-up": "高く評価",
   "playback-label-volume-down": "音量を上げる",
   "playback-label-volume-up": "音量を下げる",
+  "playback-label-info-track": "",
   "playback-os-no-track-playing": "現在再生中の曲はありません",
 
   "settings-requires-restart": "再起動が必要です",

--- a/src/_locales/nl-NL.json
+++ b/src/_locales/nl-NL.json
@@ -62,6 +62,7 @@
   "playback-label-thumbs-up": "Duim omhoog",
   "playback-label-volume-down": "Harder",
   "playback-label-volume-up": "Zachter",
+  "playback-label-info-track": "",
   "playback-os-no-track-playing": "",
 
   "settings-requires-restart": "Vereist herstart",

--- a/src/_locales/pirate.json
+++ b/src/_locales/pirate.json
@@ -62,6 +62,7 @@
   "playback-label-thumbs-up": "Ye like",
   "playback-label-volume-down": "Calm that noise",
   "playback-label-volume-up": "Arr, I can't hear you",
+  "playback-label-info-track": "",
   "playback-os-no-track-playing": "",
 
   "settings-requires-restart": "Requires ye scuttle and relaunch",

--- a/src/_locales/pl-PL.json
+++ b/src/_locales/pl-PL.json
@@ -62,6 +62,7 @@
   "playback-label-thumbs-up": "Podoba mi się",
   "playback-label-volume-down": "Zmniejsz głośność",
   "playback-label-volume-up": "Zwiększ głośność",
+  "playback-label-info-track": "",
   "playback-os-no-track-playing": "Żaden utwór nie jest teraz odtwarzany",
 
   "settings-requires-restart": "Wymaga ponownego uruchomienia",

--- a/src/_locales/pt-BR.json
+++ b/src/_locales/pt-BR.json
@@ -62,6 +62,7 @@
   "playback-label-thumbs-up": "Gostei",
   "playback-label-volume-down": "Diminuir Volume",
   "playback-label-volume-up": "Aumentar Volume",
+  "playback-label-info-track": "Notificar música atual",
   "playback-os-no-track-playing": "",
 
   "settings-requires-restart": "Requer reinicialização",

--- a/src/_locales/ro.json
+++ b/src/_locales/ro.json
@@ -62,6 +62,7 @@
   "playback-label-thumbs-up": "Îmi place",
   "playback-label-volume-down": "Scade volumul",
   "playback-label-volume-up": "Crește volumul",
+  "playback-label-info-track": "",
   "playback-os-no-track-playing": "",
 
   "settings-requires-restart": "Necesită repornirea aplicației",

--- a/src/_locales/ru.json
+++ b/src/_locales/ru.json
@@ -25,6 +25,7 @@
   "label-show-lyrics": "Показать текст песни (Бета)",
   "label-unknown-artist": "Неизвестный исполнитель",
   "label-unknown-song": "Неизвестная песня",
+  "playback-label-info-track": "",
   "label-version": "Версия",
 
   "lastfm-login-authorized": "Авторизован(а)",

--- a/src/_locales/sk.json
+++ b/src/_locales/sk.json
@@ -62,6 +62,7 @@
   "playback-label-thumbs-up": "Páči sa mi",
   "playback-label-volume-down": "Znížiť hlasitosť",
   "playback-label-volume-up": "Zvýšiť hlasitosť",
+  "playback-label-info-track": "",
   "playback-os-no-track-playing": "Neprehráva sa žiadna skladba",
 
   "settings-requires-restart": "Vyžaduje reštart",

--- a/src/_locales/ua.json
+++ b/src/_locales/ua.json
@@ -62,6 +62,7 @@
   "playback-label-thumbs-up": "Подобається",
   "playback-label-volume-down": "Зменшити гучніть",
   "playback-label-volume-up": "Збільшити гучність",
+  "playback-label-info-track": "",
   "playback-os-no-track-playing": "",
 
   "settings-requires-restart": "Потребує перезапуску",

--- a/src/main/features/core/keyboardShortcuts.js
+++ b/src/main/features/core/keyboardShortcuts.js
@@ -36,6 +36,7 @@ const customHotkeysTemplate = {
   thumbsDown: null,
   increaseVolume: null,
   decreaseVolume: null,
+  infoTrack: null,
 };
 
 const userHotkeys = Settings.get('hotkeys', {});

--- a/src/renderer/ui/components/settings/HotkeyInput.js
+++ b/src/renderer/ui/components/settings/HotkeyInput.js
@@ -26,6 +26,7 @@ class HotkeyInput extends Component {
       'thumbsDown',
       'increaseVolume',
       'decreaseVolume',
+      'infoTrack',
     ]).isRequired,
     hotkeys: PropTypes.object.isRequired,
     setSetting: PropTypes.func.isRequired,

--- a/src/renderer/ui/components/settings/tabs/HotkeyTab.js
+++ b/src/renderer/ui/components/settings/tabs/HotkeyTab.js
@@ -16,6 +16,7 @@ export default class HotkeyTab extends Component {
         <HotkeyInput label={TranslationProvider.query('playback-label-thumbs-down')} hotkeyAction="thumbsDown" />
         <HotkeyInput label={TranslationProvider.query('playback-label-volume-down')} hotkeyAction="decreaseVolume" />
         <HotkeyInput label={TranslationProvider.query('playback-label-volume-up')} hotkeyAction="increaseVolume" />
+        <HotkeyInput label={TranslationProvider.query('playback-label-info-track')} hotkeyAction="infoTrack" />
       </SettingsTabWrapper>
     );
   }

--- a/src/renderer/windows/GPMWebView/playback/controller.js
+++ b/src/renderer/windows/GPMWebView/playback/controller.js
@@ -78,9 +78,11 @@ Emitter.on('playback:miniDisable', () => {
 });
 
 Emitter.on('playback:infoTrack', () => {
-  if (!remote.getGlobal('PlaybackAPI').data.song.title) return;
-  new Notification(remote.getGlobal('PlaybackAPI').data.song.title, { // eslint-disable-line
-    body: `${remote.getGlobal('PlaybackAPI').data.song.artist} - ${remote.getGlobal('PlaybackAPI').data.song.album}`,
-    icon: remote.getGlobal('PlaybackAPI').data.song.albumArt,
+  const currentTrack = window.GPM.getCurrentTrack();
+
+  if (!window.GPM.isPlaying()) return;
+  new Notification(currentTrack.title, { // eslint-disable-line
+    body: `${currentTrack.artist} - ${currentTrack.album}`,
+    icon: currentTrack.albumArt,
   });
 });

--- a/src/renderer/windows/GPMWebView/playback/controller.js
+++ b/src/renderer/windows/GPMWebView/playback/controller.js
@@ -76,3 +76,11 @@ Emitter.on('playback:miniEnable', () => {
 Emitter.on('playback:miniDisable', () => {
   window.GPM.mini.disable();
 });
+
+Emitter.on('playback:infoTrack', () => {
+  if (!remote.getGlobal('PlaybackAPI').data.song.title) return;
+  new Notification(remote.getGlobal('PlaybackAPI').data.song.title, { // eslint-disable-line
+    body: `${remote.getGlobal('PlaybackAPI').data.song.artist} - ${remote.getGlobal('PlaybackAPI').data.song.album}`,
+    icon: remote.getGlobal('PlaybackAPI').data.song.albumArt,
+  });
+});


### PR DESCRIPTION
Simple feature but useful that add a keyboard shortcut that when fired sends a notification with information of current track.
(with portuguese translation)

![captura de tela de 2017-02-18 23-01-45](https://cloud.githubusercontent.com/assets/1341623/23098712/5080132c-f634-11e6-9d45-5af670935316.png)
![captura de tela de 2017-02-18 23-41-54](https://cloud.githubusercontent.com/assets/1341623/23098713/54711170-f634-11e6-8874-f1cb0b92fc1c.png)

