### PR TITLE
Fix misspelling in postinstall script definition

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "package:linux:32": "gulp package:linux:32",
     "package:linux:64": "gulp package:linux:64",
     "package:win": "gulp package:win",
-    "postinstall": "electron-rebuild --types=prod,optioanl",
+    "postinstall": "electron-rebuild --types=prod,optional",
     "test": "npm run lint",
     "pretest-electron": "npm run build",
     "pretest-electron-coverage": "cross-env NODE_ENV=coverage npm run build",


### PR DESCRIPTION
optional was spelled 'optioanl'