### PR TITLE
Fix ampersands in tray on Windows systems

### DIFF
--- a/src/main/features/core/tray.js
+++ b/src/main/features/core/tray.js
@@ -37,7 +37,14 @@ const getTrackString = (track) => {
     title = `${title.substring(0, 40 - (artist.length + 6))}...`;
   }
 
-  return `${title} - ${artist}`;
+  let trackString = `${title} - ${artist}`;
+
+  // fix display of ampersands on windows
+  if (process.platform === 'win32') {
+    trackString = trackString.replace('&', '&&');
+  }
+
+  return trackString;
 };
 
 let audioDeviceMenu = [

--- a/src/main/features/core/windowTitleInfo.js
+++ b/src/main/features/core/windowTitleInfo.js
@@ -8,8 +8,14 @@ const updateDarwinTitle = (newTitle) => {
   }, 200);
 };
 
+// fix display of ampersands on windows
+const replaceAmpersands = (string) => (
+  process.platform === 'win32' ? string.replace('&', '&&&') : string
+);
+
 PlaybackAPI.on('change:track', (songInfo) => {
-  const newString = `${(songInfo.title || TranslationProvider.query('label-unknown-song'))} - ${(songInfo.artist || TranslationProvider.query('label-unknown-artist'))}`; // eslint-disable-line
+  let newString = `${(songInfo.title || TranslationProvider.query('label-unknown-song'))} - ${(songInfo.artist || TranslationProvider.query('label-unknown-artist'))}`; // eslint-disable-line
+  newString = replaceAmpersands(newString);
   global.appIcon.setToolTip(newString);
   WindowManager.get(global.mainWindowID).setTitle(newString);
   updateDarwinTitle(newString);
@@ -19,6 +25,7 @@ const changeState = (stateVal) => {
   const songInfo = PlaybackAPI.currentSong(true);
   if (!songInfo) return;
   let newString = `${(songInfo.title || TranslationProvider.query('label-unknown-song'))} - ${(songInfo.artist || TranslationProvider.query('label-unknown-artist'))}`; // eslint-disable-line
+  newString = replaceAmpersands(newString);
   if (stateVal === 0) {
     newString = windowTitle;
   } else if (stateVal === 1) {

--- a/src/main/features/core/windowTitleInfo.js
+++ b/src/main/features/core/windowTitleInfo.js
@@ -14,9 +14,8 @@ const replaceAmpersands = string => (
 );
 
 PlaybackAPI.on('change:track', (songInfo) => {
-  let newString = `${(songInfo.title || TranslationProvider.query('label-unknown-song'))} - ${(songInfo.artist || TranslationProvider.query('label-unknown-artist'))}`; // eslint-disable-line
-  newString = replaceAmpersands(newString);
-  global.appIcon.setToolTip(newString);
+  const newString = `${(songInfo.title || TranslationProvider.query('label-unknown-song'))} - ${(songInfo.artist || TranslationProvider.query('label-unknown-artist'))}`; // eslint-disable-line
+  global.appIcon.setToolTip(replaceAmpersands(newString));
   WindowManager.get(global.mainWindowID).setTitle(newString);
   updateDarwinTitle(newString);
 });
@@ -25,13 +24,12 @@ const changeState = (stateVal) => {
   const songInfo = PlaybackAPI.currentSong(true);
   if (!songInfo) return;
   let newString = `${(songInfo.title || TranslationProvider.query('label-unknown-song'))} - ${(songInfo.artist || TranslationProvider.query('label-unknown-artist'))}`; // eslint-disable-line
-  newString = replaceAmpersands(newString);
   if (stateVal === 0) {
     newString = windowTitle;
   } else if (stateVal === 1) {
     newString = `(Paused) ${newString}`;
   }
-  global.appIcon.setToolTip(newString);
+  global.appIcon.setToolTip(replaceAmpersands(newString));
   WindowManager.get(global.mainWindowID).setTitle(newString);
   updateDarwinTitle(newString);
 };

--- a/src/main/features/core/windowTitleInfo.js
+++ b/src/main/features/core/windowTitleInfo.js
@@ -9,7 +9,7 @@ const updateDarwinTitle = (newTitle) => {
 };
 
 // fix display of ampersands on windows
-const replaceAmpersands = (string) => (
+const replaceAmpersands = string => (
   process.platform === 'win32' ? string.replace('&', '&&&') : string
 );
 


### PR DESCRIPTION
* fixed ampersands being stripped from hover tooltip (&&&)
* fixed ampersands being stripped from context menu (&&)

Fixes issue #2278 as well as a similar bug in the tray context menu.

---
Not sure whether the coding style in windowTitleInfo.js is what you're looking for - happy to change it.

Thanks for the opportunity to get my first contribution through 😄

EDIT: Looks like I might not pass some of the checks, I'll be back in the morning to sort it out.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/marshallofsound/google-play-music-desktop-player-unofficial-/2288)
<!-- Reviewable:end -->
