### PR TITLE
Snap package: add missing libXtst

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -42,6 +42,7 @@ parts:
     gulp-tasks:
       - package:linux:64
     build-packages:
+      - g++
       - libavahi-compat-libdnssd-dev
       - libdbus-1-dev
       - libx11-dev
@@ -56,6 +57,7 @@ parts:
       - libavahi-compat-libdnssd1
       - libxss1
       - libgconf2-4
+      - libxtst6
     after:
       - desktop-gtk2
       - indicator-gtk2


### PR DESCRIPTION
Somehow missed this in my local testing. Without this library, the snap package fails to start.

Also throw in g++ in the build environment - mdns needs a compiler. The snap builds fine in the Launchpad build environment without it, but that's because the LP environment has various build-essential packages preinstalled.