### PR TITLE
Fix back swiping

### DIFF
--- a/src/renderer/windows/GPMWebView/interface/customNavigation/mouseButtonNavigation.js
+++ b/src/renderer/windows/GPMWebView/interface/customNavigation/mouseButtonNavigation.js
@@ -10,7 +10,7 @@ const handleAppCommand = (e, cmd) => {
 
 const handleSwipeCommand = (e, direction) => {
   if (direction === 'left') {
-    remote.getCurrentWebContents.goBack();
+    remote.getCurrentWebContents().goBack();
   } else if (direction === 'right') {
     remote.getCurrentWebContents().goForward();
   }


### PR DESCRIPTION
On Mac, 3-finger swiping backwards didn't work, but swiping forwards did. This PR fixes that issue.