### PR TITLE
Added shortcut for 'close', related to #2545

### DIFF
--- a/src/main/features/core/applicationMenu.js
+++ b/src/main/features/core/applicationMenu.js
@@ -128,6 +128,11 @@ const template = [
         accelerator: 'CmdOrCtrl+W',
         role: 'close',
       },
+      {
+        label: 'Close2',
+        accelerator: 'CmdOrCtrl+Q',
+        role: 'close',
+      },
     ],
   },
   {

--- a/src/main/features/core/applicationMenu.js
+++ b/src/main/features/core/applicationMenu.js
@@ -125,12 +125,10 @@ const template = [
       },
       {
         label: 'Close',
-        accelerator: 'CmdOrCtrl+W',
-        role: 'close',
-      },
-      {
-        label: 'Close2',
-        accelerator: 'CmdOrCtrl+Q',
+        accelerator: (() => {
+          if (process.platform === 'linux') return 'CmdOrCtrl+Q';
+          return 'CmdOrCtrl+W';
+        })(),
         role: 'close',
       },
     ],

--- a/src/main/features/core/applicationMenu.js
+++ b/src/main/features/core/applicationMenu.js
@@ -125,10 +125,7 @@ const template = [
       },
       {
         label: 'Close',
-        accelerator: (() => {
-          if (process.platform === 'linux') return 'CmdOrCtrl+Q';
-          return 'CmdOrCtrl+W';
-        })(),
+        accelerator: process.platform === 'linux' ? 'CmdOrCtrl+Q' : 'CmdOrCtrl+W',
         role: 'close',
       },
     ],


### PR DESCRIPTION
Added an extra label, 'Close2', to fix issue described in #2545
There was no Linux detection as of yet, so not sure if it is meant to be done this way.