### PR TITLE
Add option to start minimized

### DIFF
--- a/src/_locales/cs.json
+++ b/src/_locales/cs.json
@@ -104,6 +104,8 @@
 
   "settings-option-save-page": "Automaticky načíst poslední stránku při spuštění",
 
+  "settings-option-start-minimized": "",
+
   "settings-option-scroll-lyrics": "Posouvat text skladby při přehrávání automaticky",
 
   "settings-option-mini-always-show": "Vždy zobraz informace o skladbě",

--- a/src/_locales/da.json
+++ b/src/_locales/da.json
@@ -104,6 +104,8 @@
 
   "settings-option-save-page": "Automatisk indlæs den sidste viste side ved start op.",
 
+  "settings-option-start-minimized": "",
+
   "settings-option-scroll-lyrics": "Automatisk rul af sangtekster når der afspilles",
 
   "settings-option-mini-always-show": "Vis altid sang informationer.",

--- a/src/_locales/de.json
+++ b/src/_locales/de.json
@@ -104,6 +104,8 @@
 
   "settings-option-save-page": "Zuletzt geöffnete Seite beim Start öffnen",
 
+  "settings-option-start-minimized": "",
+
   "settings-option-scroll-lyrics": "Liedtext automatisch scrollen",
 
   "settings-option-mini-always-show": "Immer Titelinformationen anzeigen",

--- a/src/_locales/en-US.json
+++ b/src/_locales/en-US.json
@@ -104,6 +104,8 @@
 
   "settings-option-save-page": "Automatically load last viewed page on startup",
 
+  "settings-option-start-minimized": "Start this application minimized",
+
   "settings-option-scroll-lyrics": "Scroll lyrics automatically while playing",
 
   "settings-option-mini-always-show": "Always show song information",

--- a/src/_locales/fr-FR.json
+++ b/src/_locales/fr-FR.json
@@ -104,6 +104,8 @@
 
   "settings-option-save-page": "Charger automatiquement la dernière page vue au lancement",
 
+  "settings-option-start-minimized": "",
+
   "settings-option-scroll-lyrics": "Défilement automatique des paroles",
 
   "settings-option-mini-always-show": "Toujours montrer les informations du morceau",

--- a/src/_locales/it.json
+++ b/src/_locales/it.json
@@ -104,6 +104,8 @@
 
   "settings-option-save-page": "Carica automaticamente l'ultima pagina visitata all'avvio",
 
+  "settings-option-start-minimized": "",
+
   "settings-option-scroll-lyrics": "Scorri automaticamente i testi durante la riproduzione",
 
   "settings-option-mini-always-show": "Mostra sempre le informazioni del brano",

--- a/src/_locales/ja.json
+++ b/src/_locales/ja.json
@@ -104,6 +104,8 @@
 
   "settings-option-save-page": "起動時に最後に表示したページを自動で読み込む",
 
+  "settings-option-start-minimized": "",
+
   "settings-option-scroll-lyrics": "再生中に歌詞を自動でスクロールする",
 
   "settings-option-mini-always-show": "常に曲の情報を表示する",

--- a/src/_locales/nl-NL.json
+++ b/src/_locales/nl-NL.json
@@ -104,6 +104,8 @@
 
   "settings-option-save-page": "Laad de laatst bekeken pagina automatisch bij opstarten",
 
+  "settings-option-start-minimized": "",
+
   "settings-option-scroll-lyrics": "Scroll liedteksten automatisch bij het afspelen",
 
   "settings-option-mini-always-show": "Toon altijd informatie over het nummer",

--- a/src/_locales/pirate.json
+++ b/src/_locales/pirate.json
@@ -104,6 +104,8 @@
 
   "settings-option-save-page": "Remember where ye set anchor last and load that location again when ye set sail",
 
+  "settings-option-start-minimized": "",
+
   "settings-option-scroll-lyrics": "",
 
   "settings-option-mini-always-show": "Always be showin' song information",

--- a/src/_locales/pl-PL.json
+++ b/src/_locales/pl-PL.json
@@ -104,6 +104,8 @@
 
   "settings-option-save-page": "Automatycznie załaduj ostatnio przeglądaną stronę przy starcie aplikacji",
 
+  "settings-option-start-minimized": "",
+
   "settings-option-scroll-lyrics": "Przewijaj napisy automatycznie podczas odtwarzania",
 
   "settings-option-mini-always-show": "Zawsze pokazuj informacje o utworze",

--- a/src/_locales/pt-BR.json
+++ b/src/_locales/pt-BR.json
@@ -104,6 +104,8 @@
 
   "settings-option-save-page": "Carregar ultima página vista automaticamente",
 
+  "settings-option-start-minimized": "",
+
   "settings-option-scroll-lyrics": "Rolar letra automaticamente enquanto executa",
 
   "settings-option-mini-always-show": "Sempre mostrar informações da música",

--- a/src/_locales/ro.json
+++ b/src/_locales/ro.json
@@ -104,6 +104,8 @@
 
   "settings-option-save-page": "Redeschide ultima pagină accesată la pornire",
 
+  "settings-option-start-minimized": "",
+
   "settings-option-scroll-lyrics": "Derulează automat versurile în timpul redării",
 
   "settings-option-mini-always-show": "Arată tot timpul informații despre melodie",

--- a/src/_locales/ru.json
+++ b/src/_locales/ru.json
@@ -104,6 +104,8 @@
 
   "settings-option-save-page": "При запуске автоматически открывать последнюю просмотренную страницу",
 
+  "settings-option-start-minimized": "",
+
   "settings-option-scroll-lyrics": "Автоматически прокручивать текст песни во время воспроизведения",
 
   "settings-option-mini-always-show": "Всегда показывать информацию о песне",

--- a/src/_locales/sk.json
+++ b/src/_locales/sk.json
@@ -104,6 +104,8 @@
 
   "settings-option-save-page": "Po spustení automaticky načítať poslednú zobrazenú stránku",
 
+  "settings-option-start-minimized": "",
+
   "settings-option-scroll-lyrics": "Automaticky posúvať text skladby počas prehrávania",
 
   "settings-option-mini-always-show": "Vždy zobraziť informácie o skladbe",

--- a/src/_locales/sv.json
+++ b/src/_locales/sv.json
@@ -104,6 +104,8 @@
 
   "settings-option-save-page": "Ladda automatiskt den senast visade sidan vid uppstart.",
 
+  "settings-option-start-minimized": "",
+
   "settings-option-scroll-lyrics": "Scrolla låttexter automatiskt under uppspelning",
 
   "settings-option-mini-always-show": "Visa altid låtinformation.",

--- a/src/_locales/ua.json
+++ b/src/_locales/ua.json
@@ -104,6 +104,8 @@
 
   "settings-option-save-page": "При завантаженні автоматично показати останню переглянуту сторінку",
 
+  "settings-option-start-minimized": "",
+
   "settings-option-scroll-lyrics": "Автоматично прокручувати текст пісні під час відтворення",
 
   "settings-option-mini-always-show": "Завжди показувати інформацію про пісню",

--- a/src/index.js
+++ b/src/index.js
@@ -128,12 +128,11 @@ app.setAppUserModelId('com.marshallofsound.gpmdp.core');
     // and load the index.html of the app.
     mainWindow.loadURL(`file://${__dirname}/public_html/index.html`);
 
-    // show the main window.
-    mainWindow.show();
-
     // minimize if 'start minimized' is on.
     if (Settings.get('startMinimized', false)) {
       mainWindow.minimize();
+    } else {
+      mainWindow.show();
     }
 
     require('./renderer/generic/translations');

--- a/src/index.js
+++ b/src/index.js
@@ -127,6 +127,15 @@ app.setAppUserModelId('com.marshallofsound.gpmdp.core');
 
     // and load the index.html of the app.
     mainWindow.loadURL(`file://${__dirname}/public_html/index.html`);
+
+    // show the main window.
+    mainWindow.show();
+
+    // minimize if 'start minimized' is on.
+    if (Settings.get('startMinimized', false)) {
+      mainWindow.minimize();
+    }
+
     require('./renderer/generic/translations');
     require('./main/features');
     require('./old_win32');

--- a/src/index.js
+++ b/src/index.js
@@ -128,13 +128,6 @@ app.setAppUserModelId('com.marshallofsound.gpmdp.core');
     // and load the index.html of the app.
     mainWindow.loadURL(`file://${__dirname}/public_html/index.html`);
 
-    // minimize if 'start minimized' is on.
-    if (Settings.get('startMinimized', false)) {
-      mainWindow.minimize();
-    } else {
-      mainWindow.show();
-    }
-
     require('./renderer/generic/translations');
     require('./main/features');
     require('./old_win32');

--- a/src/main/utils/_initialSettings.js
+++ b/src/main/utils/_initialSettings.js
@@ -6,6 +6,7 @@ export default {
   nativeFrame: (process.platform !== 'win32'),
   savePage: true,
   scrollLyrics: true,
+  startMinimized: false,
   theme: false,
   themeColor: '#2196F3',
   themeType: 'FULL',

--- a/src/renderer/ui/components/settings/tabs/GeneralTab.js
+++ b/src/renderer/ui/components/settings/tabs/GeneralTab.js
@@ -19,6 +19,7 @@ class GeneralTab extends Component {
         <PlatformSpecific platform="linux">
           <ToggleableOption label={TranslationProvider.query('settings-option-invert-tray-icon')} settingsKey={"appIconInvert"} />
         </PlatformSpecific>
+        <ToggleableOption label={TranslationProvider.query('settings-option-start-minimized')} settingsKey={"startMinimized"} />
         <ToggleableOption label={TranslationProvider.query('settings-option-auto-launch')} settingsKey={"auto-launch"} />
         <ToggleableOption label={TranslationProvider.query('settings-option-prevent-display-sleep')} settingsKey={"preventDisplaySleep"} />
         <ToggleableOption label={TranslationProvider.query('settings-option-keep-sidebar-open')} settingsKey={"keepSidebarOpen"} />

--- a/src/renderer/windows/main.js
+++ b/src/renderer/windows/main.js
@@ -1,4 +1,3 @@
-import { remote } from 'electron';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import injectTapEventPlugin from 'react-tap-event-plugin';
@@ -8,4 +7,3 @@ import PlayerPage from '../ui/pages/PlayerPage';
 injectTapEventPlugin();
 
 ReactDOM.render(<PlayerPage />, document.querySelector('#main-window'));
-remote.getCurrentWindow().show();

--- a/src/renderer/windows/main.js
+++ b/src/renderer/windows/main.js
@@ -1,9 +1,31 @@
+import { remote } from 'electron';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import injectTapEventPlugin from 'react-tap-event-plugin';
 
 import PlayerPage from '../ui/pages/PlayerPage';
+import SettingsClass from '../../main/utils/Settings';
 
 injectTapEventPlugin();
 
+// Instantiate a settings object for checking 'start minimized'
+if (process.env['TEST_SPEC']) { // eslint-disable-line
+  global.Settings = new SettingsClass('.test', true);
+} else {
+  global.Settings = new SettingsClass();
+}
+
 ReactDOM.render(<PlayerPage />, document.querySelector('#main-window'));
+
+// minimize if 'start minimized' is on.
+if (Settings.get('startMinimized', false)) {
+  if (Settings.get('minToTray', false)) {
+    // .minimize will show on the windows taskbar even if minToTray is true
+    // Since, minToTray is on we can safely close without killing
+    remote.getCurrentWindow().close();
+  } else {
+    remote.getCurrentWindow().minimize();
+  }
+} else {
+  remote.getCurrentWindow().show();
+}

--- a/src/renderer/windows/main.js
+++ b/src/renderer/windows/main.js
@@ -4,16 +4,8 @@ import ReactDOM from 'react-dom';
 import injectTapEventPlugin from 'react-tap-event-plugin';
 
 import PlayerPage from '../ui/pages/PlayerPage';
-import SettingsClass from '../../main/utils/Settings';
 
 injectTapEventPlugin();
-
-// Instantiate a settings object for checking 'start minimized'
-if (process.env['TEST_SPEC']) { // eslint-disable-line
-  global.Settings = new SettingsClass('.test', true);
-} else {
-  global.Settings = new SettingsClass();
-}
 
 ReactDOM.render(<PlayerPage />, document.querySelector('#main-window'));
 


### PR DESCRIPTION
Addresses issue #2260.

This pull request adds an option that allows the user to specify whether the program starts minimized or not.

It adds a new checkbox option in the **Desktop Settings** menu for the English locale.
![start minimized](https://cloud.githubusercontent.com/assets/16845804/26701494/5d4b4494-46ef-11e7-97d9-f37ed05b88ec.png)

**Notes:**
- I removed the `.show()` call from the show() call from `src/renderer/windows/main.js` and stuck one in `src/index.js`. I didn't notice any immediate problems with this, but maybe someone else knows better.
- This works by minimizing the browser window right when the program starts. If someone knows a better way to do this, advice is appreciated!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/marshallofsound/google-play-music-desktop-player-unofficial-/2564)
<!-- Reviewable:end -->
