### PR TITLE
Add application menu keyboard shortcut for showing album cover

### DIFF
--- a/src/main/features/core/applicationMenu.js
+++ b/src/main/features/core/applicationMenu.js
@@ -70,6 +70,13 @@ const template = [
         },
       },
       {
+        label: 'Show Album Cover',
+        accelerator: 'CmdOrCtrl+Shift+C',
+        click: () => {
+          Emitter.sendToGooglePlayMusic('cover:show');
+        },
+      },
+      {
         label: 'Show Lyrics (Beta)',
         accelerator: 'CmdOrCtrl+Shift+L',
         click: () => {

--- a/src/renderer/windows/GPMWebView/interface/customNavigation/index.js
+++ b/src/renderer/windows/GPMWebView/interface/customNavigation/index.js
@@ -1,3 +1,4 @@
+import './showCover';
 import './goToURL';
 import './hotkeyNavigation';
 import './mouseButtonNavigation';

--- a/src/renderer/windows/GPMWebView/interface/customNavigation/showCover.js
+++ b/src/renderer/windows/GPMWebView/interface/customNavigation/showCover.js
@@ -1,0 +1,3 @@
+Emitter.on('cover:show', () => {
+  document.getElementById('hover-icon').click();
+});

--- a/src/renderer/windows/GPMWebView/interface/customNavigation/showCover.js
+++ b/src/renderer/windows/GPMWebView/interface/customNavigation/showCover.js
@@ -1,3 +1,6 @@
 Emitter.on('cover:show', () => {
-  document.querySelector('#hover-icon').click();
+  const hoverIcon = document.querySelector('#hover-icon');
+  if (hoverIcon) {
+    hoverIcon.click();
+  }
 });

--- a/src/renderer/windows/GPMWebView/interface/customNavigation/showCover.js
+++ b/src/renderer/windows/GPMWebView/interface/customNavigation/showCover.js
@@ -1,3 +1,3 @@
 Emitter.on('cover:show', () => {
-  document.getElementById('hover-icon').click();
+  document.querySelector('#hover-icon').click();
 });


### PR DESCRIPTION
This PR adds a keyboard shortcut (Cmd/Ctrl+Shift+C) to the application menu, allowing users to show the album cover / screensaver via their keyboard. I know this may seem like something unimportant, but I, for one, use the album cover function all the time and thought it would be a nice addition, considering the lyrics view can also be opened via a keyboard shortcut.