### PR TITLE
Adds Windows 10 setting to hide track info/artwork in volume overlay

### DIFF
--- a/src/_locales/cs.json
+++ b/src/_locales/cs.json
@@ -90,6 +90,7 @@
   "settings-option-enable-taskbar-progress": "Ukázat průběh skladby na hlavním panelu",
   "settings-option-enable-win10-media-service": "",
   "settings-option-enable-win10-media-service-details": "",
+  "settings-option-enable-win10-media-service-track-info": "",
   "settings-option-change-locale": "Vybrat jazyk (Language)",
 
   "settings-option-hotkey-explanation": "Výchozí multimediální tlačítka budou fungovat jako doposud. Toto nastavení je doplňkem k výchozímu.",

--- a/src/_locales/da.json
+++ b/src/_locales/da.json
@@ -90,6 +90,7 @@
   "settings-option-enable-taskbar-progress": "Vis sangens forløb i proceslinjen.",
   "settings-option-enable-win10-media-service": "",
   "settings-option-enable-win10-media-service-details": "",
+  "settings-option-enable-win10-media-service-track-info": "",
   "settings-option-change-locale": "Vælg sprog",
 
   "settings-option-hotkey-explanation": "De almindelige medie knapper vil stadig virke, uafhængigt af denne indstilling. Disse indstillinger er ekstra indstillinger.",

--- a/src/_locales/de.json
+++ b/src/_locales/de.json
@@ -90,6 +90,7 @@
   "settings-option-enable-taskbar-progress": "Zeige den Fortschritt des Titels in der Taskleiste",
   "settings-option-enable-win10-media-service": "Aktiviere den Windows 10-System Media Service",
   "settings-option-enable-win10-media-service-details": "Dies zeigt den aktuellen Titel auf dem Sperrbildschirm",
+  "settings-option-enable-win10-media-service-track-info": "",
   "settings-option-change-locale": "Wähle eine andere Sprache",
 
   "settings-option-hotkey-explanation": "Die grundlegenden Medientasten werden dennoch funktionieren.  Diese Einstellungen kommen zu den Standardeinstellungen hinzu.",

--- a/src/_locales/en-US.json
+++ b/src/_locales/en-US.json
@@ -90,6 +90,7 @@
   "settings-option-enable-taskbar-progress": "Show track progress in the taskbar",
   "settings-option-enable-win10-media-service": "Enable the Windows 10 System Media Service",
   "settings-option-enable-win10-media-service-details": "This will show the current track on the lock screen",
+  "settings-option-enable-win10-media-service-track-info": "Show track information in Windows 10 volume overlay",
   "settings-option-change-locale": "Choose language",
 
   "settings-option-hotkey-explanation": "Default media keys will continue to work regardless of these settings.  These settings are in addition to the defaults.",

--- a/src/_locales/fr-FR.json
+++ b/src/_locales/fr-FR.json
@@ -90,6 +90,7 @@
   "settings-option-enable-taskbar-progress": "Afficher la progression du morceau dans la barre des tâches",
   "settings-option-enable-win10-media-service": "Activer le Service Multimedia de Windows 10",
   "settings-option-enable-win10-media-service-details": "Cela montrera la piste courante sur l'écran de verrouillage",
+  "settings-option-enable-win10-media-service-track-info": "",
   "settings-option-change-locale": "Choisir un langage",
 
   "settings-option-hotkey-explanation": "Les touches multimédias continueront à fonctionner malgré ces paramètres. Ceux-ci sont en complément des paramètres par défaut.",

--- a/src/_locales/it.json
+++ b/src/_locales/it.json
@@ -90,6 +90,7 @@
   "settings-option-enable-taskbar-progress": "Mostra il progresso del brano nella barra delle applicazioni",
   "settings-option-enable-win10-media-service": "Abilita il System Media Service di Windows 10",
   "settings-option-enable-win10-media-service-details": "Mostra il brano corrente nella schermata di blocco",
+  "settings-option-enable-win10-media-service-track-info": "",
   "settings-option-change-locale": "Seleziona lingua",
 
   "settings-option-hotkey-explanation": "I tasti multimediali predefiniti continueranno a funzionare indipendentemente da queste impostazioni.  Queste sono in aggiunta alle impostazioni predefinite.",

--- a/src/_locales/ja.json
+++ b/src/_locales/ja.json
@@ -90,6 +90,7 @@
   "settings-option-enable-taskbar-progress": "曲の進行状況をタスクバーに表示する",
   "settings-option-enable-win10-media-service": "Windows 10のSystem Media Serviceを有効にする",
   "settings-option-enable-win10-media-service-details": "これによりロック画面に現在の曲が表示されるようになります",
+  "settings-option-enable-win10-media-service-track-info": "",
   "settings-option-change-locale": "言語",
 
   "settings-option-hotkey-explanation": "これらの設定に関係なくデフォルトのメディアキーは引き続き機能します。 これらの設定はデフォルトに追加するものです",

--- a/src/_locales/nl-NL.json
+++ b/src/_locales/nl-NL.json
@@ -90,6 +90,7 @@
   "settings-option-enable-taskbar-progress": "",
   "settings-option-enable-win10-media-service": "",
   "settings-option-enable-win10-media-service-details": "",
+  "settings-option-enable-win10-media-service-track-info": "",
   "settings-option-change-locale": "",
 
   "settings-option-hotkey-explanation": "Standaard mediatoetsen zullen blijven werken onafhankelijk van deze instellingen.  Deze instellingen zijn een toevoeging aan de standaard instellingen.",

--- a/src/_locales/pirate.json
+++ b/src/_locales/pirate.json
@@ -90,6 +90,7 @@
   "settings-option-enable-taskbar-progress": "Show track progress in th' taskbar",
   "settings-option-enable-win10-media-service": "Tell ye' OS what track be playin'",
   "settings-option-enable-win10-media-service-details": "",
+  "settings-option-enable-win10-media-service-track-info": "",
   "settings-option-change-locale": "Choose how ye speak",
 
   "settings-option-hotkey-explanation": "Default media keys gunna continue to set the sails regardless 'o these settin's. These settin's be in addition to th' defaults.",

--- a/src/_locales/pl-PL.json
+++ b/src/_locales/pl-PL.json
@@ -90,6 +90,7 @@
   "settings-option-enable-taskbar-progress": "Pokazuj postęp utworu na pasku systemowym",
   "settings-option-enable-win10-media-service": "Włącz System Media Service (Windows 10)",
   "settings-option-enable-win10-media-service-details": "Ta funkcja pozwala wyświetlać aktualny utwór na ekranie blokady",
+  "settings-option-enable-win10-media-service-track-info": "",
   "settings-option-change-locale": "Wybierz język aplikacji",
 
   "settings-option-hotkey-explanation": "Domyślne klawisze dedykowane obsłudze mediów będą działać bez względu na te ustawienia. Traktuj te ustawienia jako dodatkowe.",

--- a/src/_locales/pt-BR.json
+++ b/src/_locales/pt-BR.json
@@ -90,6 +90,7 @@
   "settings-option-enable-taskbar-progress": "Mostrar o progresso da musica na barra de tarefas",
   "settings-option-enable-win10-media-service": "",
   "settings-option-enable-win10-media-service-details": "",
+  "settings-option-enable-win10-media-service-track-info": "",
   "settings-option-change-locale": "Escolher linguagem",
 
   "settings-option-hotkey-explanation": "Teclas de mídia padrão continuarão a funcionar independente das configurações. Estas configurações apenas complementam as demais teclas.",

--- a/src/_locales/ro.json
+++ b/src/_locales/ro.json
@@ -90,6 +90,7 @@
   "settings-option-enable-taskbar-progress": "Arată progresul melodiei în bara de sistem",
   "settings-option-enable-win10-media-service": "",
   "settings-option-enable-win10-media-service-details": "",
+  "settings-option-enable-win10-media-service-track-info": "",
   "settings-option-change-locale": "Alege limba",
 
   "settings-option-hotkey-explanation": "Tastele media vor continua să funcționeze indiferent de aceste setări. Aceste setări vin ca o completare peste cele implicite.",

--- a/src/_locales/ru.json
+++ b/src/_locales/ru.json
@@ -90,6 +90,7 @@
   "settings-option-enable-taskbar-progress": "Показывать позицию воспроизведения в панели задач",
   "settings-option-enable-win10-media-service": "",
   "settings-option-enable-win10-media-service-details": "",
+  "settings-option-enable-win10-media-service-track-info": "",
   "settings-option-change-locale": "Язык программы",
 
   "settings-option-hotkey-explanation": "Стандартные мультимедийные кнопки всё равно будут работать, независимо от дополнительных, представленных ниже.",

--- a/src/_locales/sk.json
+++ b/src/_locales/sk.json
@@ -90,6 +90,7 @@
   "settings-option-enable-taskbar-progress": "Zobraziť priebeh skladby na panely úloh",
   "settings-option-enable-win10-media-service": "Povoliť Windows 10 System Media Service",
   "settings-option-enable-win10-media-service-details": "Zobrazí aktuálnu skladbu na uzamknutej obrazovke",
+  "settings-option-enable-win10-media-service-track-info": "",
   "settings-option-change-locale": "Vybrať jazyk",
 
   "settings-option-hotkey-explanation": "Predvolené mediálne klávesy budú stále fungovať bez ohľadu na tieto nastavenia.  Tieto nastavenia sú ako doplnok k predvoleným.",

--- a/src/_locales/sv.json
+++ b/src/_locales/sv.json
@@ -90,6 +90,7 @@
   "settings-option-enable-taskbar-progress": "Visa låtens förlopp i processraden.",
   "settings-option-enable-win10-media-service": "Aktivera Windows 10-mediatjänsten",
   "settings-option-enable-win10-media-service-details": "Detta kommer att visa nuvarande låten på låsskärmen",
+  "settings-option-enable-win10-media-service-track-info": "",
   "settings-option-change-locale": "Välj språk",
 
   "settings-option-hotkey-explanation": "De almänna mediaknapparna kommer fortsätta funka, oberoende av denna inställningen. Dessa inställningar är extrainställningar.",

--- a/src/_locales/ua.json
+++ b/src/_locales/ua.json
@@ -90,6 +90,7 @@
   "settings-option-enable-taskbar-progress": "Відобразити прогрес відтворення в панелі",
   "settings-option-enable-win10-media-service": "Увімкнути медіа сервіс Windows 10",
   "settings-option-enable-win10-media-service-details": "Буде показувати активний трек на екрані блокування",
+  "settings-option-enable-win10-media-service-track-info": "",
   "settings-option-change-locale": "Обрати мову",
 
   "settings-option-hotkey-explanation": "Типові мультимедіа кнопки все одно будуть працювати незалежно від цих налаштувань. Ці налаштування для додаткових типових значень.",

--- a/src/main/utils/_initialSettings.js
+++ b/src/main/utils/_initialSettings.js
@@ -11,4 +11,5 @@ export default {
   themeType: 'FULL',
   preventDisplaySleep: false,
   enableWin10MediaService: false,
+  enableWin10MediaServiceTrackInfo: true,
 };

--- a/src/renderer/ui/components/settings/ToggleableOption.js
+++ b/src/renderer/ui/components/settings/ToggleableOption.js
@@ -27,9 +27,9 @@ class SettingsCheckbox extends Component {
           : null}
       </span>
     );
-    const dependsOnSettingsKey = this.props.dependsOnSettingsKey;
+    const { dependsOnSettingsKey } = this.props;
     if (dependsOnSettingsKey && !this.props[dependsOnSettingsKey]) {
-      return <noscript />;
+      return null;
     }
 
     return (
@@ -65,7 +65,7 @@ export default class ToggleableOption extends Component {
       settingsKey: this.props.settingsKey,
       dependsOnSettingsKey: this.props.dependsOnSettingsKey,
     };
-    let keys = [this.props.settingsKey];
+    const keys = [this.props.settingsKey];
     if (this.props.dependsOnSettingsKey) {
       keys.push(this.props.dependsOnSettingsKey);
     }

--- a/src/renderer/ui/components/settings/ToggleableOption.js
+++ b/src/renderer/ui/components/settings/ToggleableOption.js
@@ -11,6 +11,7 @@ class SettingsCheckbox extends Component {
     settingsKey: PropTypes.string.isRequired,
     setSetting: PropTypes.func.isRequired,
     muiTheme: PropTypes.object,
+    dependsOnSettingsKey: PropTypes.string,
   };
 
   onChange = (event, isChecked) => {
@@ -26,6 +27,10 @@ class SettingsCheckbox extends Component {
           : null}
       </span>
     );
+    const dependsOnSettingsKey = this.props.dependsOnSettingsKey;
+    if (dependsOnSettingsKey && !this.props[dependsOnSettingsKey]) {
+      return <noscript />;
+    }
 
     return (
       <Checkbox
@@ -50,6 +55,7 @@ export default class ToggleableOption extends Component {
     label: PropTypes.string.isRequired,
     hintLabel: PropTypes.string,
     settingsKey: PropTypes.string.isRequired,
+    dependsOnSettingsKey: PropTypes.string,
   };
 
   render() {
@@ -57,10 +63,14 @@ export default class ToggleableOption extends Component {
       label: this.props.label,
       hintLabel: this.props.hintLabel,
       settingsKey: this.props.settingsKey,
+      dependsOnSettingsKey: this.props.dependsOnSettingsKey,
     };
-
+    let keys = [this.props.settingsKey];
+    if (this.props.dependsOnSettingsKey) {
+      keys.push(this.props.dependsOnSettingsKey);
+    }
     return (
-      <SettingsProvider component={ThemedSettingsCheckbox} componentProps={checkboxProps} keys={[this.props.settingsKey]} defaults={{}} />
+      <SettingsProvider component={ThemedSettingsCheckbox} componentProps={checkboxProps} keys={keys} defaults={{}} />
     );
   }
 }

--- a/src/renderer/ui/components/settings/tabs/GeneralTab.js
+++ b/src/renderer/ui/components/settings/tabs/GeneralTab.js
@@ -57,6 +57,15 @@ class GeneralTab extends Component {
             settingsKey={"enableWin10MediaService"}
           />
         </PlatformSpecific>
+        <PlatformSpecific platform="win32" versionRange=">=10">
+          <ToggleableOption
+            label={TranslationProvider.query('settings-option-enable-win10-media-service-track-info')}
+            hintLabel={TranslationProvider.query('settings-requires-restart')}
+            settingsKey={"enableWin10MediaServiceTrackInfo"}
+            dependsOnSettingsKey={"enableWin10MediaService"}
+          />
+        </PlatformSpecific>
+
         <LocaleSelector />
       </SettingsTabWrapper>
     );

--- a/src/renderer/windows/GPMWebView/playback/systemMediaService/win10.js
+++ b/src/renderer/windows/GPMWebView/playback/systemMediaService/win10.js
@@ -15,7 +15,9 @@ Controls.isPreviousEnabled = true;
 Controls.isRecordEnabled = false;
 Controls.isRewindEnabled = false;
 Controls.isStopEnabled = true;
-
+if (!Settings.get('enableWin10MediaServiceTrackInfo')) {
+  Controls.isEnabled = false;
+}
 Controls.playbackStatus = MediaPlaybackStatus.closed;
 Controls.displayUpdater.type = MediaPlaybackType.music;
 


### PR DESCRIPTION
This PR applies the feature described here:  #2590 

The new setting is only visible in Windows 10 and when the existing "enableWin10MediaService" setting is enabled.