### PR TITLE
Add the music media.role for PulseAudio

### DIFF
--- a/vendor/snap/google-play-music-desktop-player.desktop
+++ b/vendor/snap/google-play-music-desktop-player.desktop
@@ -7,3 +7,4 @@ Icon=main.png
 Type=Application
 StartupNotify=true
 Categories=AudioVideo;Audio;
+X-PulseAudio-Properties=media.role=music


### PR DESCRIPTION
This sets the media.role label on media stream to "music" so PulseAudio's corking mechanism can work properly.

See this post on reddit for more detail on this. https://www.reddit.com/r/linux/comments/2rjiaa/horrible_decisions_flat_volumes_in_pulseaudio_a/cngt9a6/