### PR TITLE
Add support for try-supported-channel-layouts flag

### DIFF
--- a/src/_locales/cs.json
+++ b/src/_locales/cs.json
@@ -114,7 +114,7 @@
   "settings-option-mini-use-scroll-volume": "Použít rolovací kolečko pro změnu hlasitosti",
 
   "settings-option-skip-bad-songs": "",
-  "settings-option-try-supported-channel-layouts": "Vyzkoušet podporované rozložení kanálů (vyžaduje restart, mělo by opravit 5.1 zvuk)",
+  "settings-option-try-supported-channel-layouts": "Experimentální podpora více audio kanálů, jako je 5.1",
 
   "settings-options-style-description": "Vybrat místní CSS soubor pro použití stylů v aplikaci",
   "settings-options-style-main-app": "Hlavní aplikace",

--- a/src/_locales/cs.json
+++ b/src/_locales/cs.json
@@ -114,6 +114,7 @@
   "settings-option-mini-use-scroll-volume": "Použít rolovací kolečko pro změnu hlasitosti",
 
   "settings-option-skip-bad-songs": "",
+  "settings-option-try-supported-channel-layouts": "Vyzkoušet podporované rozložení kanálů (vyžaduje restart, mělo by opravit 5.1 zvuk)",
 
   "settings-options-style-description": "Vybrat místní CSS soubor pro použití stylů v aplikaci",
   "settings-options-style-main-app": "Hlavní aplikace",

--- a/src/_locales/da.json
+++ b/src/_locales/da.json
@@ -114,6 +114,7 @@
   "settings-option-mini-use-scroll-volume": "Brug rullehjulet til at justere lydstyrken",
 
   "settings-option-skip-bad-songs": "",
+  "settings-option-try-supported-channel-layouts": "",
 
   "settings-options-style-description": "Vælg en lokal CSS fil, til at tilpasse programmet.",
   "settings-options-style-main-app": "Hovedvinduet",

--- a/src/_locales/de.json
+++ b/src/_locales/de.json
@@ -114,6 +114,7 @@
   "settings-option-mini-use-scroll-volume": "Mausrad zur Lautstärkekontrolle verwenden",
 
   "settings-option-skip-bad-songs": "Überspringe automatisch nicht gemochte Titel",
+  "settings-option-try-supported-channel-layouts": "",
 
   "settings-options-style-description": "Wähle eine lokale CSS-Datei, um eigene Stile in die Anwendung einzubringen",
   "settings-options-style-main-app": "Hauptfenster",

--- a/src/_locales/en-US.json
+++ b/src/_locales/en-US.json
@@ -114,6 +114,7 @@
   "settings-option-mini-use-scroll-volume": "Use the scroll wheel to adjust volume",
 
   "settings-option-skip-bad-songs": "Automatically skip disliked songs",
+  "settings-option-try-supported-channel-layouts": "Try supported channel layouts (requires restart, should fix 5.1 sound)",
 
   "settings-options-style-description": "Choose a local CSS file to inject styles into the application",
   "settings-options-style-main-app": "Main App",

--- a/src/_locales/en-US.json
+++ b/src/_locales/en-US.json
@@ -114,7 +114,7 @@
   "settings-option-mini-use-scroll-volume": "Use the scroll wheel to adjust volume",
 
   "settings-option-skip-bad-songs": "Automatically skip disliked songs",
-  "settings-option-try-supported-channel-layouts": "Try supported channel layouts (requires restart, should fix 5.1 sound)",
+  "settings-option-try-supported-channel-layouts": "Experimental support for multiple audio channels such as 5.1 audio",
 
   "settings-options-style-description": "Choose a local CSS file to inject styles into the application",
   "settings-options-style-main-app": "Main App",

--- a/src/_locales/es-ES.json
+++ b/src/_locales/es-ES.json
@@ -113,6 +113,7 @@
   "settings-option-mini-use-scroll-volume": "Usa la rueda del ratón para ajustar el volumen",
 
   "settings-option-skip-bad-songs": "Saltar canciones con 'No me gusta' automáticamente",
+  "settings-option-try-supported-channel-layouts": "",
 
   "settings-options-style-description": "Escoger un fichero CSS local para utilizarlo en la aplicación",
   "settings-options-style-main-app": "Aplicación Principal",

--- a/src/_locales/fr-FR.json
+++ b/src/_locales/fr-FR.json
@@ -114,6 +114,7 @@
   "settings-option-mini-use-scroll-volume": "Utiliser la molette de la souris pour ajuster le volume",
 
   "settings-option-skip-bad-songs": "Passer automatiquement les pistes notées négativement",
+  "settings-option-try-supported-channel-layouts": "",
 
   "settings-options-style-description": "Choisir un fichier CSS local pour injecter du style dans l'application",
   "settings-options-style-main-app": "Application principale",

--- a/src/_locales/it.json
+++ b/src/_locales/it.json
@@ -114,6 +114,7 @@
   "settings-option-mini-use-scroll-volume": "Usa la rotella di scorrimento per regolare il volume",
 
   "settings-option-skip-bad-songs": "Salta automaticamente i brani segnati con pollice giù",
+  "settings-option-try-supported-channel-layouts": "",
 
   "settings-options-style-description": "Seleziona un file CSS locale per iniettare gli stili nell'applicazione",
   "settings-options-style-main-app": "Applicazione principale",

--- a/src/_locales/ja.json
+++ b/src/_locales/ja.json
@@ -114,6 +114,7 @@
   "settings-option-mini-use-scroll-volume": "音量調節にスクロールホイールを利用する",
 
   "settings-option-skip-bad-songs": "",
+  "settings-option-try-supported-channel-layouts": "",
 
   "settings-options-style-description": "アプリケーションにスタイルを適用するためのローカルCSSファイルを選択する",
   "settings-options-style-main-app": "メインアプリ",

--- a/src/_locales/nl-NL.json
+++ b/src/_locales/nl-NL.json
@@ -114,6 +114,7 @@
   "settings-option-mini-use-scroll-volume": "Gebruik het muiswieltje om het volume aan te passen",
 
   "settings-option-skip-bad-songs": "",
+  "settings-option-try-supported-channel-layouts": "",
 
   "settings-options-style-description": "",
   "settings-options-style-main-app": "",

--- a/src/_locales/pirate.json
+++ b/src/_locales/pirate.json
@@ -114,6 +114,7 @@
   "settings-option-mini-use-scroll-volume": "",
 
   "settings-option-skip-bad-songs": "",
+  "settings-option-try-supported-channel-layouts": "",
 
   "settings-options-style-description": "Choose a local CSS file to inject styles into th' ship",
   "settings-options-style-main-app": "Main App",

--- a/src/_locales/pl-PL.json
+++ b/src/_locales/pl-PL.json
@@ -114,6 +114,7 @@
   "settings-option-mini-use-scroll-volume": "Użyj rolki myszki aby sterować głośnością",
 
   "settings-option-skip-bad-songs": "Automatycznie pomijaj nielubiane utwory",
+  "settings-option-try-supported-channel-layouts": "",
 
   "settings-options-style-description": "Wybierz lokalny plik CSS aby dodać nowe style do aplikacji",
   "settings-options-style-main-app": "Główna aplikacja",

--- a/src/_locales/pt-BR.json
+++ b/src/_locales/pt-BR.json
@@ -114,6 +114,7 @@
   "settings-option-mini-use-scroll-volume": "Use o scroll do mouse para controlar o volume",
 
   "settings-option-skip-bad-songs": "",
+  "settings-option-try-supported-channel-layouts": "",
 
   "settings-options-style-description": "Escolha um arquivo CSS local para injetar no aplicativo",
   "settings-options-style-main-app": "Aplicativo Principal",

--- a/src/_locales/ro.json
+++ b/src/_locales/ro.json
@@ -114,6 +114,7 @@
   "settings-option-mini-use-scroll-volume": "Folosește rotița mouse-ului pentru a ajusta volumul",
 
   "settings-option-skip-bad-songs": "",
+  "settings-option-try-supported-channel-layouts": "",
 
   "settings-options-style-description": "Alege un fișier CSS pentru a injecta stilul în aplicație",
   "settings-options-style-main-app": "Aplicație GPMDP",

--- a/src/_locales/ru.json
+++ b/src/_locales/ru.json
@@ -114,6 +114,7 @@
   "settings-option-mini-use-scroll-volume": "Управление громкостью колесом мыши",
 
   "settings-option-skip-bad-songs": "Автоматически пропускать непонравившиеся песни",
+  "settings-option-try-supported-channel-layouts": "",
 
   "settings-options-style-description": "Выберите локальный CSS-файл для инъекции стилей в приложение",
   "settings-options-style-main-app": "Стили приложения",

--- a/src/_locales/sk.json
+++ b/src/_locales/sk.json
@@ -114,6 +114,7 @@
   "settings-option-mini-use-scroll-volume": "Použiť koliesko myši pre nastavenie hlasitosti",
 
   "settings-option-skip-bad-songs": "Automaticky preskočiť skladby, ktoré sa vám nepáčia",
+  "settings-option-try-supported-channel-layouts": "",
 
   "settings-options-style-description": "Zvoľte miestny CSS súbor pre použitie vlastného štýlu v aplikácii",
   "settings-options-style-main-app": "Hlavná apl.",

--- a/src/_locales/sv.json
+++ b/src/_locales/sv.json
@@ -114,6 +114,7 @@
   "settings-option-mini-use-scroll-volume": "Använd scrollhjulet för att justera volymen",
 
   "settings-option-skip-bad-songs": "Hoppa automatiskt över ogillade låtar",
+  "settings-option-try-supported-channel-layouts": "",
 
   "settings-options-style-description": "Välj en lokal CSS-fil, för att anpassa programmet.",
   "settings-options-style-main-app": "Huvudfönstret",

--- a/src/_locales/ua.json
+++ b/src/_locales/ua.json
@@ -114,6 +114,7 @@
   "settings-option-mini-use-scroll-volume": "Керування гічністю за допомогою коліщатка миши",
 
   "settings-option-skip-bad-songs": "Автоматично пропускати пісні, що не сподобались",
+  "settings-option-try-supported-channel-layouts": "",
 
   "settings-options-style-description": "Оберіть локальний CSS-файл для застосування стилей в застосунку",
   "settings-options-style-main-app": "Стилі додатку",

--- a/src/main/configureApp.js
+++ b/src/main/configureApp.js
@@ -8,6 +8,9 @@ export default (app) => {
   // DEV: Enables the HTML5 WebAudio API extensions to allow selection of sinkId
   //      --> Choosing audio output device
   app.commandLine.appendSwitch('enable-experimental-web-platform-features', '1');
+  if (Settings.get('trySupportedChannelLayouts', false)) {
+    app.commandLine.appendSwitch('try-supported-channel-layouts', '1');
+  }
 
   if (process.platform !== 'darwin') {
     app.disableHardwareAcceleration();

--- a/src/main/configureApp.js
+++ b/src/main/configureApp.js
@@ -8,6 +8,8 @@ export default (app) => {
   // DEV: Enables the HTML5 WebAudio API extensions to allow selection of sinkId
   //      --> Choosing audio output device
   app.commandLine.appendSwitch('enable-experimental-web-platform-features', '1');
+
+  // Required for 5.1 sound support
   if (Settings.get('trySupportedChannelLayouts', false)) {
     app.commandLine.appendSwitch('try-supported-channel-layouts', '1');
   }

--- a/src/renderer/ui/components/settings/tabs/PlaybackTab.js
+++ b/src/renderer/ui/components/settings/tabs/PlaybackTab.js
@@ -9,7 +9,11 @@ export default class PlaybackTab extends Component {
     return (
       <SettingsTabWrapper>
         <AudioDeviceSelector />
-        <ToggleableOption label={TranslationProvider.query('settings-option-try-supported-channel-layouts')} settingsKey={"trySupportedChannelLayouts"} />
+        <ToggleableOption
+          label={TranslationProvider.query('settings-option-try-supported-channel-layouts')}
+          settingsKey={"trySupportedChannelLayouts"}
+          hintLabel={TranslationProvider.query('settings-requires-restart')}
+        />
         <ToggleableOption label={TranslationProvider.query('settings-option-skip-bad-songs')} settingsKey={"skipBadSongs"} />
       </SettingsTabWrapper>
     );

--- a/src/renderer/ui/components/settings/tabs/PlaybackTab.js
+++ b/src/renderer/ui/components/settings/tabs/PlaybackTab.js
@@ -9,6 +9,7 @@ export default class PlaybackTab extends Component {
     return (
       <SettingsTabWrapper>
         <AudioDeviceSelector />
+        <ToggleableOption label={TranslationProvider.query('settings-option-try-supported-channel-layouts')} settingsKey={"trySupportedChannelLayouts"} />
         <ToggleableOption label={TranslationProvider.query('settings-option-skip-bad-songs')} settingsKey={"skipBadSongs"} />
       </SettingsTabWrapper>
     );


### PR DESCRIPTION
This PR adds new setting value, which allow users to launch the player with `try-supported-channel-layouts` flag, which can fix 5.1 channel support for some people.

This change was discussed at #2380 and should fix it.