### PR TITLE
Remove default 'Recents' sidebar button

### DIFF
--- a/src/renderer/windows/GPMWebView/interface/customUI.js
+++ b/src/renderer/windows/GPMWebView/interface/customUI.js
@@ -132,15 +132,10 @@ function installAlarmButton() {
   });
 }
 
-function installRecentsButton() {
-  installSidebarButton('label-recents', 'recents', 'history', 0, '#/recents');
-}
-
 function installMainMenu() {
   installDesktopSettingsButton();
   installQuitButton();
   installAlarmButton();
-  installRecentsButton();
 }
 
 /* eslint-disable max-len, no-multi-str */


### PR DESCRIPTION
The sidebar and the side menu seems to be populated by GPM. Since the "Recents" button is added automatically if the user's subscription allows this feature, it's unnecessary to manually add the button (we also can't detect if the user is subscribed to GPM or not). Fixes #2463.