### PR TITLE
Use HTTP for lastfm calls

### DIFF
--- a/src/main/features/core/lastFM.js
+++ b/src/main/features/core/lastFM.js
@@ -7,6 +7,7 @@ import { LASTFM_API_KEY, LASTFM_API_SECRET } from '../../constants';
 const lastfm = new LastFmNode({
   api_key: LASTFM_API_KEY,
   secret: LASTFM_API_SECRET,
+  host: 'https://ws.audioscrobbler.com',
   useragent: 'GPMDP',
 });
 


### PR DESCRIPTION
I just noticed in Wireshark that all requests send to LastFM are made with http although https is supported and their default.
I didn't test this change, but it should be an obvious one. :blush: 