### PR TITLE
Discord Rich Presence 

### DIFF
--- a/src/main/features/core/discordRickPresence.js
+++ b/src/main/features/core/discordRickPresence.js
@@ -56,7 +56,7 @@ const setPresence = () => {
     };
 
     if (queueTrackIndex > queueLength || !queueTrackIndex) {
-      delete presence.pratySize;
+      delete presence.partySize;
       delete presence.partyMax;
     }
 

--- a/src/main/features/core/discordRickPresence.js
+++ b/src/main/features/core/discordRickPresence.js
@@ -5,6 +5,7 @@ let client;
 
 let lastTrack = null;
 let lastStart = new Date(0);
+let lastPlayingState = false;
 
 const setPresence = () => {
   if (!Settings.get('discordRichPresence', false)) return;
@@ -12,30 +13,69 @@ const setPresence = () => {
   client = client || createDiscordClient('391934620418965504');
   const time = PlaybackAPI.currentTime();
   const currentTrack = PlaybackAPI.currentSong();
+  const isPlaying = PlaybackAPI.isPlaying();
+  const queue = PlaybackAPI.getQueue();
   const track = currentTrack || lastTrack;
+  if (!time.current) return;
   const start = new Date(Date.now() - time.current);
-  if (JSON.stringify(track) !== JSON.stringify(lastTrack) || Math.round(start.getTime() / 1000) !== Math.round(lastStart.getTime() / 1000)) {
+  if (JSON.stringify(track) !== JSON.stringify(lastTrack)
+      || Math.round(start.getTime() / 1000) !== Math.round(lastStart.getTime() / 1000)
+      || isPlaying !== lastPlayingState) {
     const end = new Date(start.getTime() + time.total);
     lastTrack = track;
     lastStart = start;
+    lastPlayingState = isPlaying;
 
     if (!track) return;
 
-    client.updatePresence({
-      state: `👤  ${track.artist}`,
-      details: `🎵  ${track.title}`,
+    let queueTrackIndex = 0;
+    let queueLength = 0;
+
+    // kinda hacky way to get index of song in playlist.
+    // this wont work properly if the paylist is all one song.
+    if (queue instanceof Array) {
+      queueLength = queue.length;
+      for (let i = 0; i < queue.length; i++) {
+        if (track.title !== queue[i].title) continue;
+        if (track.album !== queue[i].album) continue;
+        if (track.artist !== queue[i].artist) continue;
+        queueTrackIndex = queue[i].index;
+      }
+    }
+
+    const presence = {
+      state: track.title,
+      details: `Album ${track.album} by ${track.artist}`,
       startTimestamp: start,
       endTimestamp: end,
       instance: false,
       largeImageKey: 'playing',
       largeImageText: 'Google Play Music',
-    });
+      partySize: queueTrackIndex,
+      partyMax: queueLength,
+    };
+
+    if (queueTrackIndex > queueLength || !queueTrackIndex) {
+      delete presence.pratySize;
+      delete presence.partyMax;
+    }
+
+    if (!isPlaying) {
+      presence.smallImageKey = 'pause';
+      presence.smallImageText = 'Paused';
+      delete presence.startTimestamp;
+      delete presence.endTimestamp;
+      presence.state += ' (Paused)';
+    }
+
+    client.updatePresence(presence);
   }
 };
 
 app.on('before-quit', () => {
-  client.updatePresence();
+  client.disconnect();
 });
 
+PlaybackAPI.on('change:state', setPresence);
 PlaybackAPI.on('change:track', setPresence);
 PlaybackAPI.on('change:time', setPresence);


### PR DESCRIPTION
I've added more information to the Rich Presence Integration. 

- Play/Pause State
- Queue Length & current song in queue (using group size and players)
- Fixed a bug causing `00:00 left` to be displayed for initial song

![Playing State](https://cdn.discordapp.com/attachments/324908432534798336/394359577904283649/unknown.png)
![Paused State](https://cdn.discordapp.com/attachments/324908432534798336/394359598011908096/unknown.png)


These changes do need a new image for paused state. 
- Type: small
- Name: pause
- Source: [Download from here](https://cdn.discordapp.com/attachments/324908432534798336/394363318703489025/unknown.png)

Known Issues: 
1. If a queue contains one song many times it will always select the last occurrence of the song.
2. `PLAYING` state instead of `LISTENING` this is a limit of RPC and cant be changed yet.
3. If a user is idle or the queue is finished, the paused state will still be active. A potential solution would be to have the RPC interaction on a child process that can be killed and therefor the Rich Presence integration can toggled on and off. 