### PR TITLE
Adds missing Brazilian Portuguese texts

### DIFF
--- a/src/_locales/pt-BR.json
+++ b/src/_locales/pt-BR.json
@@ -14,7 +14,7 @@
 
   "label-about": "Sobre",
   "label-alarm": "Despertador",
-  "label-recents": "",
+  "label-recents": "Recentes",
   "label-desktop-settings": "Configurações desktop",
   "label-donate": "Doar",
   "label-help": "Ajuda",
@@ -34,7 +34,7 @@
   "lastfm-login-error": "Você pode ter fechado a página de autorização. Se você acha que é um engano, tente novamente",
   "lastfm-login-not-authorized": "Não autorizado",
   "lastfm-logout-button-text": "Sair do Last.FM",
-  "lastfm-map-thumbs-up-to-heart": "",
+  "lastfm-map-thumbs-up-to-heart": "Marcar automaticamente faixas curtidas como faixas preferidas no Last.fm",
 
   "listenbrainz-label-user-token": "Digite seu token de usuário no ListenBrainz (pode ser encontrado em https://listenbrainz.org/user/info)",
   "listenbrainz-token-here": "",
@@ -62,7 +62,7 @@
   "modal-welcome-content": "Esperamos que goste da nova atualização!",
 
   "playback-label-next-track": "Próxima faixa",
-  "playback-label-play-pause": "Play / Pause",
+  "playback-label-play-pause": "Tocar / Pausar",
   "playback-label-previous-track": "Faixa anterior",
   "playback-label-stop": "Parar",
   "playback-label-thumbs-down": "Não gostei",
@@ -70,15 +70,15 @@
   "playback-label-volume-down": "Diminuir Volume",
   "playback-label-volume-up": "Aumentar Volume",
   "playback-label-info-track": "Notificar música atual",
-  "playback-os-no-track-playing": "",
-  "playback-label-im-feeling-lucky": "",
+  "playback-os-no-track-playing": "Nenhuma faixa tocando",
+  "playback-label-im-feeling-lucky": "Estou com sorte",
 
   "settings-requires-restart": "Requer reinicialização",
 
-  "settings-option-keep-sidebar-open": "",
-  "settings-option-static-album-art": "",
+  "settings-option-keep-sidebar-open": "Manter a barra lateral aberta",
+  "settings-option-static-album-art": "Manter arte do álbum estática no visualizador",
 
-  "settings-option-invert-tray-icon": "",
+  "settings-option-invert-tray-icon": "Inverter a cor do ícone da bandeja",
 
   "settings-option-custom-theme": "Tema personalizado",
   "settings-option-custom-theme-choose-color": "Escolha a cor de destaque do tema",
@@ -86,7 +86,7 @@
   "settings-option-custom-theme-custom-color": "Cor personalizada",
   "settings-option-custom-theme-dark": "Escuro",
   "settings-option-custom-theme-light": "Claro",
-  "settings-option-custom-theme-should-track-system": "",
+  "settings-option-custom-theme-should-track-system": "Aplicar modo escuro do sistema ao tipo de tema",
 
   "settings-option-enable-api": "Habilitar PlaybackAPI",
   "settings-option-enable-api-json": "Habilitar API JSON",
@@ -95,24 +95,24 @@
   "settings-option-enable-voice": "Habilitar Controles de Voz",
   "settings-option-enable-voice-details": "Habilita controle de voz do GPMDP, recurso experimental",
   "settings-option-enable-taskbar-progress": "Mostrar o progresso da musica na barra de tarefas",
-  "settings-option-enable-win10-media-service": "",
-  "settings-option-enable-win10-media-service-details": "",
+  "settings-option-enable-win10-media-service": "Habilitar o serviço de mídia do Windows 10",
+  "settings-option-enable-win10-media-service-details": "Este recurso mostrará a faixa tocando na tela de bloqueio",
   "settings-option-discord-rich-presence": "",
-  "settings-option-enable-win10-media-service-track-info": "",
-  "settings-option-change-locale": "Escolher linguagem",
+  "settings-option-enable-win10-media-service-track-info": "Exibir informação da faixa atual no balão de volume do Windows 10",
+  "settings-option-change-locale": "Escolher idioma",
 
   "settings-option-hotkey-explanation": "Teclas de mídia padrão continuarão a funcionar independente das configurações. Estas configurações apenas complementam as demais teclas.",
   "settings-option-hotkey-explanation-2": "Use a tecla <i>\"Esc\"</i> para redefinir o atalho.",
-  "settings-option-hotkey-not-set": "",
+  "settings-option-hotkey-not-set": "Não configurado",
 
   "settings-option-min-to-tray": "Minimizar para a bandeja",
 
-  "settings-option-prevent-display-sleep": "",
+  "settings-option-prevent-display-sleep": "Impedir que o computador entre em modo de hibernação enquanto o GPMDP estiver aberto",
   "settings-option-auto-launch": "Inicializar automaticamente junto com o computador",
 
   "settings-option-save-page": "Carregar ultima página vista automaticamente",
 
-  "settings-option-start-minimized": "",
+  "settings-option-start-minimized": "Iniciar o aplicativo minimizado",
 
   "settings-option-scroll-lyrics": "Rolar letra automaticamente enquanto executa",
 
@@ -120,17 +120,17 @@
   "settings-option-mini-ontop": "Sempre no topo",
   "settings-option-mini-use-scroll-volume": "Use o scroll do mouse para controlar o volume",
 
-  "settings-option-skip-bad-songs": "",
-  "settings-option-try-supported-channel-layouts": "",
+  "settings-option-skip-bad-songs": "Pular automaticamente faixas marcadas como 'Não gostei'",
+  "settings-option-try-supported-channel-layouts": "Suporte, ainda em fase experimental, a múltiplos canais de áudio, como por exemplo Áudio 5.1",
 
   "settings-options-style-description": "Escolha um arquivo CSS local para injetar no aplicativo",
   "settings-options-style-main-app": "Aplicativo Principal",
   "settings-options-style-gpm": "Google Play Música",
   "settings-options-style-refresh": "Recarregar estilos",
-  "settings-options-style-dialog-title": "",
-  "settings-options-style-dialog-button": "",
-  "settings-options-style-dialog-css-files": "",
-  "settings-options-style-dialog-all-files": "",
+  "settings-options-style-dialog-title": "Escolha um arquivo CSS",
+  "settings-options-style-dialog-button": "Carregar CSS",
+  "settings-options-style-dialog-css-files": "Arquivos CSS",
+  "settings-options-style-dialog-all-files": "Todos os arquivos",
 
   "title-color-picker": "Paleta de cores",
   "title-settings": "Configurações",


### PR DESCRIPTION
I have added missing pt-br texts and have changed two which already was defined.

In the line 65, despite the terms "Play/Pause" is common between brazilians, I think the portuguese version is more applicable, because they exist among other players.

In the line 102, although a good translation, "linguagem" is a term not applicable to "language". Brazilian are more comfortable with "idioma".

Thank you!