### PR TITLE
Add dock menu for Playback controls on darwin platform

### DIFF
--- a/src/main/features/core/applicationMenu.js
+++ b/src/main/features/core/applicationMenu.js
@@ -234,3 +234,8 @@ if (global.DEV_MODE) {
 
 const menu = Menu.buildFromTemplate(template);
 Menu.setApplicationMenu(menu);
+
+if (process.platform === 'darwin') {
+  // Add Playback menu options to Dock menu
+  app.dock.setMenu(Menu.buildFromTemplate(template[3].submenu));
+}


### PR DESCRIPTION
Allow ability to use playback controls (play/pause, previous, next) from the Dock icon contextual menu on macOS