### PR TITLE
Update node-engine in snapcraft.yaml

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -36,7 +36,7 @@ parts:
 
   google-play-music-desktop-player:
     plugin: gulp
-    node-engine: 7.2.1
+    node-engine: 8.9.4
     source: .
     source-type: git
     gulp-tasks:


### PR DESCRIPTION
discord.js requires node 8, which is probably why 4.5.0 isn't in the Snap Store yet.