### PR TITLE
Remove album from details in Discord Rich Presence

### DIFF
--- a/src/main/features/core/discordRichPresence.js
+++ b/src/main/features/core/discordRichPresence.js
@@ -48,7 +48,7 @@ const setPresence = () => {
 
     const presence = {
       state: track.title,
-      details: `Album ${track.album} by ${track.artist}`,
+      details: track.artist,
       startTimestamp: start,
       endTimestamp: end,
       instance: false,


### PR DESCRIPTION
The album name is arguably the least important part of the song description, yet in the current implementation it comes before artist. This often causes text clipping in discord, hiding the artist name whilst showing the album it's on.

This also works better for singles, as the name of the song is duplicated in the current implementation (as album name == song name). Overall, it's simply a cleaner way of displaying song info.

A surprisingly common example below:
![image](https://user-images.githubusercontent.com/22318278/35940758-15661e50-0c48-11e8-9dbb-d5c1f58e2d36.png)

Notice how Everchanging is duplicated top and bottom, and Haywyre (the artist) is only visible by the letter "H"

Instead, why not display it like this?
![image](https://user-images.githubusercontent.com/22318278/35940796-30bf2ed0-0c48-11e8-97cf-48543ca1c3fc.png)