### PR TITLE
 it('should not fire change on position ...

### DIFF
--- a/test/electron/Settings_spec.js
+++ b/test/electron/Settings_spec.js
@@ -65,7 +65,7 @@ describe('Settings', () => {
     hookCalled.should.be.equal(true);
   });
 
-  it('should not fire changa function when the position key is changed', () => {
+  it('should not fire change function on position key when another key is changed', () => {
     let hookCalled = false;
     settings.onChange('test_key', () => {
       hookCalled = true;


### PR DESCRIPTION
It's not clear, but it seems to be testing that no side effect trigger happens on `position` key if another key is changed.

If this is the intended test I tried to word it a bit better.  

If the intended test really was to `it('should not fire change function when the position key is changed'` then we probably need to change: 

```js
settings.onChange('test_key', () => {
      hookCalled = true;
    });
```

to 

```js
settings.onChange('position', () => {
      hookCalled = true;
    });
```