### PR TITLE
Show player after clicking Help->About in tray icon menu

### DIFF
--- a/src/main/features/core/tray.js
+++ b/src/main/features/core/tray.js
@@ -125,6 +125,8 @@ const setContextMenu = (track) => {
           label: TranslationProvider.query('label-about'),
           click: () => {
             Emitter.sendToWindowsOfName('main', 'about');
+            mainWindow.setSkipTaskbar(false);
+            mainWindow.show();
           },
         },
         {


### PR DESCRIPTION
I fulfilled the simple feature request in [#2998](https://github.com/MarshallOfSound/Google-Play-Music-Desktop-Player-UNOFFICIAL-/issues/2998) by showing the window upon clicking Help->About in the tray icon menu.