### PR TITLE
Add Gentoo OS support in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ OS Support
 * Mint
 * Fedora
 * Debian
+* [Gentoo](https://github.com/Atoms/rukruk) from Overlay
 
 Features
 --------


### PR DESCRIPTION
Add Gentoo OS support in Readme 
for installation on Gentoo use eselect to enable repository rukruk (`eselect repository enable rukruk`) and then `emerge media-sound/google-play-music-desktop-player-bin` 