### PR TITLE
Changed update URL as xyz TLD was being blocked on my work PC

### DIFF
--- a/src/main/features/core/autoUpdater.js
+++ b/src/main/features/core/autoUpdater.js
@@ -9,7 +9,7 @@ if (process.platform === 'darwin') {
 const setUpAutoUpdate = () => {
   if (global.DEV_MODE) return;
   try {
-    autoUpdater.setFeedURL(`https://update.gpmdp.xyz/update/${platform}/${app.getVersion()}`);
+    autoUpdater.setFeedURL(`https://update.googleplaymusicdesktopplayer.com/update/${platform}/${app.getVersion()}`);
 
     autoUpdater.on('error', (error) => {
       // Ignore it, errors happen
@@ -63,7 +63,7 @@ const setUpAutoUpdate = () => {
 };
 
 const checkUpdateServer = () => {
-  https.get('https://update.gpmdp.xyz', () => {
+  https.get('https://update.googleplaymusicdesktopplayer.com', () => {
     setUpAutoUpdate();
   }).on('error', () => {
     Logger.error('################### !! Update server down !! ##################');


### PR DESCRIPTION
Feel free to use this PR or close it.  I made the change for myself as it appears GPMDP is checking for updates about every 2 minutes 15 seconds.  This was causing me to get spammed with notifications from Symantec saying that a URL was blocked.

 I may be the only one whose work is blocking the xyz TLD.