### PR TITLE
Debounce forward/previous on the emitter to prevent double skipping

### DIFF
--- a/src/renderer/windows/GPMWebView/playback/controller.js
+++ b/src/renderer/windows/GPMWebView/playback/controller.js
@@ -17,9 +17,9 @@ window.wait(() => {
   );
 });
 
-Emitter.on('playback:playPause', () => {
-  window.GPM.playback.playPause();
-});
+Emitter.on('playback:playPause',
+  _.debounce(window.GPM.playback.playPause, 300, { leading: true })
+);
 
 Emitter.on('playback:play:smooth', () => {
   const originalVolume = window.GPM.volume.getVolume();

--- a/src/renderer/windows/GPMWebView/playback/controller.js
+++ b/src/renderer/windows/GPMWebView/playback/controller.js
@@ -8,7 +8,7 @@ window.wait(() => {
     mode = newMode;
   });
 
-  Emitter.on('playback:previousTrack', 
+  Emitter.on('playback:previousTrack',
     _.debounce(window.GPM.playback.rewind, 300, { leading: true })
   );
 

--- a/src/renderer/windows/GPMWebView/playback/controller.js
+++ b/src/renderer/windows/GPMWebView/playback/controller.js
@@ -1,4 +1,5 @@
 import { remote } from 'electron';
+import _ from 'lodash';
 
 let mode;
 window.wait(() => {
@@ -6,10 +7,14 @@ window.wait(() => {
   window.GPM.on('change:playback', (newMode) => {
     mode = newMode;
   });
-});
 
-Emitter.on('playback:previousTrack', () => {
-  window.GPM.playback.rewind();
+  Emitter.on('playback:previousTrack', 
+    _.debounce(window.GPM.playback.rewind, 300, { leading: true })
+  );
+
+  Emitter.on('playback:nextTrack',
+    _.debounce(window.GPM.playback.forward, 300, { leading: true })
+  );
 });
 
 Emitter.on('playback:playPause', () => {
@@ -31,10 +36,6 @@ Emitter.on('playback:play:smooth', () => {
       clearInterval(fadeIn);
     }
   }, 20);
-});
-
-Emitter.on('playback:nextTrack', () => {
-  window.GPM.playback.forward();
 });
 
 Emitter.on('playback:stop', () => {

--- a/src/renderer/windows/GPMWebView/playback/systemMediaService/win10.js
+++ b/src/renderer/windows/GPMWebView/playback/systemMediaService/win10.js
@@ -38,11 +38,9 @@ Controls.on('buttonpressed', (sender, eventArgs) => {
       break;
     case SystemMediaTransportControlsButton.next:
       Emitter.fireAtGoogle('playback:nextTrack');
-      // GPM.playback.forward();
       break;
     case SystemMediaTransportControlsButton.previous:
       Emitter.fireAtGoogle('playback:previousTrack');
-      // GPM.playback.rewind();
       break;
     default:
       break;

--- a/src/renderer/windows/GPMWebView/playback/systemMediaService/win10.js
+++ b/src/renderer/windows/GPMWebView/playback/systemMediaService/win10.js
@@ -37,10 +37,12 @@ Controls.on('buttonpressed', (sender, eventArgs) => {
       if (GPM.playback.isPlaying()) GPM.playback.playPause();
       break;
     case SystemMediaTransportControlsButton.next:
-      GPM.playback.forward();
+      Emitter.fireAtGoogle('playback:nextTrack');
+      // GPM.playback.forward();
       break;
     case SystemMediaTransportControlsButton.previous:
-      GPM.playback.rewind();
+      Emitter.fireAtGoogle('playback:previousTrack');
+      // GPM.playback.rewind();
       break;
     default:
       break;


### PR DESCRIPTION
Maybe fixes #2364. Test before merging. 