### PR TITLE
bugfix/hide-duplicate-menu

### DIFF
--- a/src/renderer/windows/GPMWebView/interface/customUI.js
+++ b/src/renderer/windows/GPMWebView/interface/customUI.js
@@ -222,7 +222,7 @@ const setKeepSidebarOpen = (keepSidebarOpen) => {
   if (keepSidebarOpen) {
     sidebar.removeAttribute('force-narrow');
     sidebar.removeAttribute('narrow');
-    openSidebarStyles = cssRule('#material-app-bar .music-logo-link { display: none !important; }');
+    openSidebarStyles = cssRule('#material-app-bar .music-logo-link, #quickNavContainer { display: none !important; }');
   } else {
     sidebar.setAttribute('force-narrow', '');
     sidebar.setAttribute('narrow', '');


### PR DESCRIPTION
**Task**: Hide the floating quick menu (home, music library, recents, ...) when the desktop settings option 'Keep sidebar open' is selected.

**Implementation**: Added a css selector in existing logic.

Requested in issue #2986 