### PR TITLE
Slack integration to update status

### DIFF
--- a/src/_locales/en-US.json
+++ b/src/_locales/en-US.json
@@ -132,6 +132,9 @@
   "settings-options-style-dialog-css-files": "CSS Files",
   "settings-options-style-dialog-all-files": "All Files",
 
+  "slack-token-label": "Enter your slack user token (can be found at https://api.slack.com/custom-integrations/legacy-tokens)",
+  "slack-token-placeholder": "Slack token",
+
   "title-color-picker": "Color Picker",
   "title-settings": "Settings",
   "title-settings-playback": "Playback",
@@ -141,6 +144,7 @@
   "title-settings-listenbrainz": "ListenBrainz",
   "title-settings-mini": "Mini Player",
   "title-settings-style": "Custom Styles",
+  "title-settings-slack": "Slack",
 
   "tray-label-audio-device": "Audio Device",
   "tray-label-show": "Show"

--- a/src/main/features/core/index.js
+++ b/src/main/features/core/index.js
@@ -17,3 +17,4 @@ import './alarm.js';
 import './sleepPreventor';
 import './mediaService';
 import './discordRichPresence';
+import './slack';

--- a/src/main/features/core/slack.js
+++ b/src/main/features/core/slack.js
@@ -1,0 +1,84 @@
+import _ from 'lodash';
+import { app } from 'electron';
+import { WebClient } from '@slack/client';
+
+const EMOJI = ':headphones:';
+
+const formatTrackForStatus = (title, artist) => {
+  const text = `${title} - ${artist}`;
+
+  if (text.length < 100) {
+    return text;
+  }
+
+  return `${text.substr(0, 97)}...`;
+};
+
+const getStatusResetProfileUpdate = () => ({
+  profile: {
+    status_emoji: '',
+    status_text: '',
+  },
+});
+
+const getProfileUpdateForTrack = (title, artist) => ({
+  profile: {
+    status_emoji: EMOJI,
+    status_text: formatTrackForStatus(title, artist),
+  },
+});
+
+function getProfileUpdate(title, artist, reset) {
+  Logger.debug('Currently Playing: ', PlaybackAPI.isPlaying(), title, artist);
+
+  if (PlaybackAPI.isPlaying() && !reset) {
+    return getProfileUpdateForTrack(title, artist);
+  }
+
+  return getStatusResetProfileUpdate();
+}
+
+let client;
+
+const getClient = () => {
+  if (!Settings.get('slackToken')) {
+    Logger.debug('No slack token set');
+    return null;
+  }
+
+  client = client || new WebClient(Settings.get('slackToken'));
+
+  return client;
+};
+
+const updateStatus = (reset = false) => {
+  const slackClient = getClient();
+
+  if (!slackClient) {
+    return;
+  }
+
+  const {
+    title,
+    artist,
+  } = PlaybackAPI.currentSong(true);
+
+  const profileUpdate = getProfileUpdate(title, artist, reset);
+  Logger.debug('Updating profile status: ', profileUpdate);
+
+  client.users.profile
+    .set(profileUpdate)
+    .then(result => {
+      Logger.debug('Profile status updated on slack: ', result);
+    })
+    .catch(err => {
+      Logger.error('Error updating profile status', err);
+    });
+};
+
+const statusUpdater = _.debounce(() => _.delay(updateStatus, 1000), 1000);
+
+PlaybackAPI.on('change:state', statusUpdater);
+PlaybackAPI.on('change:track', statusUpdater);
+
+app.on('before-quit', updateStatus.bind(null, true));

--- a/src/renderer/ui/components/settings/tabs/SlackTab.js
+++ b/src/renderer/ui/components/settings/tabs/SlackTab.js
@@ -1,0 +1,26 @@
+import React, { Component, PropTypes } from 'react';
+
+import SettingsTabWrapper from './SettingsTabWrapper';
+import TextFieldSettings from '../TextFieldSettings';
+import { requireSettings } from '../../generic/SettingsProvider';
+
+class SlackTab extends Component {
+  static propTypes = {
+    setSetting: PropTypes.func.isRequired,
+  };
+
+  render() {
+    return (
+      <SettingsTabWrapper>
+        <h4>{TranslationProvider.query('slack-token-label')}</h4>
+        <TextFieldSettings
+          label={TranslationProvider.query('slack-token-label')}
+          settingsKey={'slackToken'}
+          placeholder={TranslationProvider.query('slack-token-placeholder')}
+        />
+      </SettingsTabWrapper>
+    );
+  }
+}
+
+export default requireSettings(SlackTab, ['slackToken'], { slackToken: '' });

--- a/src/renderer/ui/pages/SettingsPage.js
+++ b/src/renderer/ui/pages/SettingsPage.js
@@ -8,6 +8,7 @@ import ListenBrainzTab from '../components/settings/tabs/ListenBrainzTab';
 import MiniTab from '../components/settings/tabs/MiniTab';
 import PlaybackTab from '../components/settings/tabs/PlaybackTab';
 import StyleTab from '../components/settings/tabs/StyleTab';
+import SlackTab from '../components/settings/tabs/SlackTab';
 import WindowContainer from '../components/generic/WindowContainer';
 
 const styles = {
@@ -48,6 +49,9 @@ export default class SettingsPage extends Component {
           </Tab>
           <Tab label={TranslationProvider.query('title-settings-style')}>
             <StyleTab />
+          </Tab>
+          <Tab label={TranslationProvider.query('title-settings-slack')}>
+            <SlackTab />
           </Tab>
         </Tabs>
       </WindowContainer>

--- a/test/electron-renderer/ui/tabs/SlackTab_spec.js
+++ b/test/electron-renderer/ui/tabs/SlackTab_spec.js
@@ -1,0 +1,17 @@
+/* eslint-disable no-unused-expressions */
+
+import React from 'react';
+import chai from 'chai';
+import { mount } from 'enzyme';
+
+import SlackTab from '../../../../build/renderer/ui/components/settings/tabs/SlackTab';
+import materialUIContext from '../_materialUIContext';
+
+chai.should();
+
+describe('<SlackTab />', () => {
+  it('should render a SettingsTabWrapper', () => {
+    const component = mount(<SlackTab />, materialUIContext);
+    component.find('SettingsTabWrapper').length.should.be.equal(1);
+  });
+});


### PR DESCRIPTION
# Description

I use [Slack](https://slack.com/) at work as well as for several private groups. I previously wrote a small script that uses the playback api to update my slack status on some of my slack teams. Right now its just a script that runs locally but I wanted to see it integrated as an actual feature so I've created this PR.
 
I know the contribution guidlines suggest asking before adding features, but I already had the core of the functionality written out for my own purposes so this was mainly just adding the setting page.

# Usage

Updates the status emoji to the headphones emoji and status text to the song and artist.

<img width="316" alt="screen shot 2018-05-05 at 2 14 31 pm" src="https://user-images.githubusercontent.com/355574/39667313-259aded2-5081-11e8-99e6-0f73a1728b6b.png">

Status is reset when playback stops or when the app is closed.

<img width="222" alt="screen shot 2018-05-05 at 2 15 46 pm" src="https://user-images.githubusercontent.com/355574/39667322-43869daa-5081-11e8-99f8-c723fba4c568.png">


# Testing

I added a spec for the new setting page. However, I couldn't seem to find any pattern for testing core features. If I missed a spot to put those tests, I'd be happy to add unit tests for `slack.js`.

# Questions

It's common for slack users to be part of multiple teams. I'm in 9 teams and would really like for this to update my status on 4 of them. I couldn't find a pattern for dynamically adding settings or where the setting value is an array and the user can dynamically add new values. Alternatively, I considered letting the field be a comma-delimited list of tokens but that feels hacky from a user's perspective. Is there a way to achieve something like this?

# Todo

- [ ] Unit testing for `slack.js` if there is a convention/place to add it
- [ ] Adding entries to all of the locales (that part might actually probably take more time than the rest of this,  so I wanted to make sure this feature was acceptable before doing that part)