### PR TITLE
update dependencies and appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -58,4 +58,4 @@ build_script:
 - cmd: npm run make:win
 
 artifacts:
-  - path: 'dist\installers\win32\Google Play Music Desktop PlayerSetup.exe'
+  - path: 'dist\installers\win32\Google.Play.Music.Desktop.PlayerSetup.exe'

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "archiver": "^1.0.1",
     "auto-launch": "^4.0.0",
     "discord-rich-presence": "^0.0.7",
-    "electron": "2.0.8",
+    "electron": "2.0.12",
     "electron-chromecast": "^1.1.0",
     "gmusic-mini-player.js": "^2.0.10",
     "gmusic-theme.js": "^2.1.16",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1376,7 +1376,7 @@ chai-fs@chaijs/chai-fs:
   resolved "https://codeload.github.com/chaijs/chai-fs/tar.gz/e59d5523eed89c6d9f6cee54265e9fc5aad37cb1"
   dependencies:
     bit-mask "^1.0.1"
-    readdir-enhanced "^1.4.0"
+    readdir-enhanced "^2.0.0"
 
 chai@^3.5.0:
   version "3.5.0"
@@ -2299,9 +2299,9 @@ electron-windows-store@^0.9.3:
     multiline "^1.0.2"
     path-exists "^3.0.0"
 
-electron@2.0.8:
-  version "2.0.8"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-2.0.8.tgz#6ec7113b356e09cc9899797e0d41ebff8163e962"
+electron@2.0.12:
+  version "2.0.12"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-2.0.12.tgz#04b11ef3246cd2a5839a8f16314051341dc5c449"
   dependencies:
     "@types/node" "^8.0.24"
     electron-download "^3.0.1"


### PR DESCRIPTION
This is a huge mix of things that I can separate if you want.

disable npm audit since you said it's confusing.
removed node_modules cache, not sure why that was there since you delete the folder in the install step anyway?
set the Windows installer file name to be the same as used before with manual releases
update appveyor to use node 8 and current npm