### PR TITLE
Make thumbs up/down options in the tray menu work as checkboxes

### DIFF
--- a/src/main/features/core/tray.js
+++ b/src/main/features/core/tray.js
@@ -127,11 +127,15 @@ const setContextMenu = (track) => {
     { type: 'separator' },
     {
       label: TranslationProvider.query('playback-label-thumbs-up'),
+      type: 'checkbox',
       click: () => Emitter.sendToGooglePlayMusic('playback:thumbsUp'),
+      checked: (PlaybackAPI.getRating().liked),
     },
     {
       label: TranslationProvider.query('playback-label-thumbs-down'),
+      type: 'checkbox',
       click: () => Emitter.sendToGooglePlayMusic('playback:thumbsDown'),
+      checked: (PlaybackAPI.getRating().disliked),
     },
     { type: 'separator' },
     {
@@ -266,4 +270,8 @@ Emitter.on('audiooutput:set', () => Emitter.sendToGooglePlayMusic('audiooutput:f
 
 PlaybackAPI.on('change:track', (track) => {
   setContextMenu(track);
+});
+
+PlaybackAPI.on('change:rating', () => {
+  setContextMenu(PlaybackAPI.currentSong());
 });

--- a/src/renderer/windows/GPMWebView/playback/controller.js
+++ b/src/renderer/windows/GPMWebView/playback/controller.js
@@ -45,20 +45,28 @@ Emitter.on('playback:stop', () => {
 
 Emitter.on('playback:thumbsUp', () => {
   if (!remote.getGlobal('PlaybackAPI').data.song.title) return;
-  new Notification('You just liked', { // eslint-disable-line
-    body: remote.getGlobal('PlaybackAPI').data.song.title,
-    icon: remote.getGlobal('PlaybackAPI').data.song.albumArt,
-  });
-  window.GPM.rating.setRating(5);
+  if (window.GPM.rating.getRating() !== '5') {
+    new Notification('You just liked', { // eslint-disable-line
+      body: remote.getGlobal('PlaybackAPI').data.song.title,
+      icon: remote.getGlobal('PlaybackAPI').data.song.albumArt,
+    });
+    window.GPM.rating.setRating(5);
+  } else {
+    window.GPM.rating.resetRating();
+  }
 });
 
 Emitter.on('playback:thumbsDown', () => {
   if (!remote.getGlobal('PlaybackAPI').data.song.title) return;
-  new Notification('You just disliked', { // eslint-disable-line
-    body: remote.getGlobal('PlaybackAPI').data.song.title,
-    icon: remote.getGlobal('PlaybackAPI').data.song.albumArt,
-  });
-  window.GPM.rating.setRating(1);
+  if (window.GPM.rating.getRating() !== '0') {
+    new Notification('You just disliked', { // eslint-disable-line
+      body: remote.getGlobal('PlaybackAPI').data.song.title,
+      icon: remote.getGlobal('PlaybackAPI').data.song.albumArt,
+    });
+    window.GPM.rating.setRating(1);
+  } else {
+    window.GPM.rating.resetRating();
+  }
 });
 
 Emitter.on('playback:increaseVolume', () => {


### PR DESCRIPTION
This PR makes the thumbs up/down options in the system tray work like checkboxes rather than plain buttons. 

So when a track is played, if it has already been rated the appropriate option in the tray will be shown checked. Changing the rating or setting one for the first time, either through the tray or through the main player window, updates the other properly (so you can unrate a track through the tray which wasn't possible before).