### PR TITLE
Small performance enhancements

### DIFF
--- a/src/assets/less/main_window.less
+++ b/src/assets/less/main_window.less
@@ -88,12 +88,14 @@ html, body {
   }
 
   #lyrics_back {
+    display: none;
     top: 100vh;
     left: 0;
     width: 100vw;
     height: 100vh;
 
     &.vis {
+      display: block;
       top: 0;
     }
   }
@@ -236,7 +238,7 @@ html, body {
     display: flex;
     height: 100%;
     width: 100%;
-    
+
     #search-link {
       position: absolute;
       bottom: 70px;

--- a/src/assets/less/util/loader.less
+++ b/src/assets/less/util/loader.less
@@ -2,7 +2,7 @@
 @import "../_variables.less";
 
 .loader {
-  position: absolute;;
+  display: none;
   margin: 0px auto;
   width: @loader-width;
   top: 0;
@@ -15,6 +15,7 @@
   overflow: hidden;
 
   [loading] & {
+    position: absolute;
     opacity: 1;
     z-index: 10;
   }

--- a/src/assets/less/util/loader.less
+++ b/src/assets/less/util/loader.less
@@ -2,7 +2,7 @@
 @import "../_variables.less";
 
 .loader {
-  display: none;
+  position: absolute;
   margin: 0px auto;
   width: @loader-width;
   top: 0;
@@ -15,7 +15,6 @@
   overflow: hidden;
 
   [loading] & {
-    position: absolute;
     opacity: 1;
     z-index: 10;
   }
@@ -24,6 +23,10 @@
     content:'';
     display: block;
     padding-top: 100%;
+  }
+
+  &.hidden {
+    display: none;
   }
 }
 

--- a/src/renderer/ui/components/generic/LyricsViewer.js
+++ b/src/renderer/ui/components/generic/LyricsViewer.js
@@ -122,20 +122,14 @@ class LyricsViewer extends Component {
     Emitter.on('lyrics:show', this.show);
     Emitter.on('PlaybackAPI:change:lyrics', this.lyricsHandler);
     Emitter.on('PlaybackAPI:change:state', this.stateHandler);
-    Emitter.on('PlaybackAPI:change:time', this.timeHandler);
     Emitter.on('settings:set:scrollLyrics', this.scrollSettingsHandler);
-
-    window.addEventListener('resize', this.startAnimating);
   }
 
   _unhook() {
     Emitter.off('lyrics:show', this.show);
     Emitter.off('PlaybackAPI:change:lyrics', this.lyricsHandler);
     Emitter.off('PlaybackAPI:change:state', this.stateHandler);
-    Emitter.off('PlaybackAPI:change:time', this.timeHandler);
     Emitter.off('settings:set:scrollLyrics', this.scrollSettingsHandler);
-
-    window.removeEventListener('resize', this.startAnimating);
   }
 
   handleLyricsNotFound() {
@@ -147,9 +141,14 @@ class LyricsViewer extends Component {
     this.setState({
       visible: false,
     });
+    Emitter.off('PlaybackAPI:change:time', this.timeHandler);
+    window.removeEventListener('resize', this.startAnimating);
   }
 
   show = () => {
+    Emitter.on('PlaybackAPI:change:time', this.timeHandler);
+    window.addEventListener('resize', this.startAnimating);
+
     this.setState({
       visible: true,
     });

--- a/src/renderer/ui/pages/PlayerPage.js
+++ b/src/renderer/ui/pages/PlayerPage.js
@@ -67,8 +67,8 @@ export default class PlayerPage extends Component {
       }, 900);
       setTimeout(() => {
         this.setState({
-          loading: false
-        })
+          loading: false,
+        });
       }, 2000);
     }
   }

--- a/src/renderer/ui/pages/PlayerPage.js
+++ b/src/renderer/ui/pages/PlayerPage.js
@@ -30,6 +30,7 @@ export default class PlayerPage extends Component {
         Settings.get('lastYTMPage', 'https://music.youtube.com/')
         : 'https://music.youtube.com/';
       this.state = {
+        loading: true,
         webviewTarget: 'https://music.youtube.com/',
         title: 'Youtube Music Desktop Player',
       };
@@ -38,6 +39,7 @@ export default class PlayerPage extends Component {
         Settings.get('lastPage', 'https://play.google.com/music/listen')
         : 'https://play.google.com/music/listen';
       this.state = {
+        loading: true,
         webviewTarget: 'https://play.google.com/music/listen#/wmp',
         title: 'Google Play Music Desktop Player',
       };
@@ -63,6 +65,11 @@ export default class PlayerPage extends Component {
       setTimeout(() => {
         document.body.removeAttribute('loading');
       }, 900);
+      setTimeout(() => {
+        this.setState({
+          loading: false
+        })
+      }, 2000);
     }
   }
 
@@ -121,7 +128,7 @@ export default class PlayerPage extends Component {
     return (
       <WindowContainer isMainWindow title={process.platform === 'darwin' ? this.state.title : ''} confirmClose={this._confirmCloseWindow}>
         <div className="drag-handle-large"></div>
-        <div className="loader">
+        <div className={`loader ${this.state.loading ? '' : 'hidden'}`}>
           <svg className="circular" viewBox="25 25 50 50">
             <circle className="path" cx="50" cy="50" r="20" fill="none" strokeWidth="2" strokeMiterlimit="10" />
           </svg>

--- a/test/electron-renderer/ui/LyricsViewer_spec.js
+++ b/test/electron-renderer/ui/LyricsViewer_spec.js
@@ -42,7 +42,6 @@ describe('<LyricsViewer />', () => {
     hooks['lyrics:show'].should.be.ok;
     hooks['PlaybackAPI:change:lyrics'].should.be.ok;
     hooks['PlaybackAPI:change:state'].should.be.ok;
-    hooks['PlaybackAPI:change:time'].should.be.ok;
     hooks['settings:set:scrollLyrics'].should.be.ok;
   });
 
@@ -51,8 +50,13 @@ describe('<LyricsViewer />', () => {
     unhooks['lyrics:show'].should.be.ok;
     unhooks['PlaybackAPI:change:lyrics'].should.be.ok;
     unhooks['PlaybackAPI:change:state'].should.be.ok;
-    unhooks['PlaybackAPI:change:time'].should.be.ok;
     unhooks['settings:set:scrollLyrics'].should.be.ok;
+  });
+
+  it('should hook into the time event when shown', () => {
+    mount(<LyricsViewer />);
+    mockEvent('lyrics:show');
+    hooks['PlaybackAPI:change:time'].should.be.ok;
   });
 
   it('should show when recieving the show event', () => {


### PR DESCRIPTION
This isn't going to magically make the app use 0.1% usage, but it should help a little. The loading icon was causing repaints when the app was open and idle, this hides the element completely when not in use, eliminating repaints. 

Same principle applies to the Lyrics Viewer. I noticed a bit of timing and jQuery calls being made when the viewer wasn't even open when playing music. When the viewer is hidden its actually hidden via display none. The timing event emitters are also not enabled until the lyrics viewer is visible to reduce constant CPU usage from repaint calculations. We may be able to apply this type of change elsewhere to save some more CPU usage. 