### PR TITLE
Set GTK dark theme if dark theme is enabled

### DIFF
--- a/src/main/configureBrowser.js
+++ b/src/main/configureBrowser.js
@@ -18,6 +18,7 @@ export default () => {
     autoHideMenuBar: true,
     frame: Settings.get('nativeFrame'),
     titleBarStyle: Settings.get('nativeFrame') && process.platform === 'darwin' ? 'hidden' : 'default',
+    darkTheme: Settings.get('themeType') === 'FULL',
     icon: path.resolve(`${__dirname}/../assets/img/main.${(process.platform === 'win32' ? 'ico' : 'png')}`), // eslint-disable-line
     title: 'Google Play Music Desktop Player',
     webPreferences: {


### PR DESCRIPTION
Should fix #3541, but I have yet to test.