### PR TITLE
Add `libavahi-compat-libdnssd-dev` to Linux dev requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,10 @@ Dev Requirements
 * Node.js (Recommend `6.3.x`)
 * NPM (3.x.x)
 
+### Linux
+
+- libavahi-compat-libdnssd-dev (or the equivalent for your distribution)
+
 Continuous Integration
 ------------------------
 


### PR DESCRIPTION
This is needed to resolve an error about missing `dns_sd.h` on Ubuntu 18.04 and elementary OS 5 Juno.