### PR TITLE
Fix waitForAudio for youtube-music

### DIFF
--- a/src/renderer/windows/GPMWebView/playback/audioEQ.js
+++ b/src/renderer/windows/GPMWebView/playback/audioEQ.js
@@ -3,8 +3,10 @@ import _ from 'lodash';
 import { setAudioDevice } from './audioSelection';
 
 window.wait(() => {
+  const service = Settings.get('service');
+  const audioSelector = service === 'youtube-music' ? 'video' : 'audio:not(.offscreen)';
   const waitForAudio = setInterval(() => {
-    if (document.querySelectorAll('audio.offscreen').length > 0 && document.querySelectorAll('audio:not(.offscreen)').length > 0) {
+    if (document.querySelectorAll(audioSelector).length > 0) {
       clearInterval(waitForAudio);
 
       // DEV: We do this here so that we can set the output device before hooking the context
@@ -15,7 +17,7 @@ window.wait(() => {
             _.forEach(devices, (device) => {
               if (device.label === Settings.get('audiooutput')) {
                 set = true;
-                Array.prototype.forEach.call(document.querySelectorAll('audio:not(.offscreen)'), (audioElem) => {
+                Array.prototype.forEach.call(document.querySelectorAll(audioSelector), (audioElem) => {
                   let once = true;
                   audioElem.addEventListener('playing', () => {
                     if (!once) return;


### PR DESCRIPTION
`waitForAudio` never stopped in `youtube-music` mode as Youtube music uses `<video>`.

It caused high idle CPU usage. On my MBP idle CPU usage by webview process was constantly 7-8% and CPU usage when music was playing was around 11-12%.

With this fix, idle CPU usage is ~2% and playback around ~5% 🎉.

May be related to https://github.com/MarshallOfSound/Google-Play-Music-Desktop-Player-UNOFFICIAL-/issues/2766
