### PR TITLE
Upgrade to electron 4

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -70,20 +70,6 @@ jobs:
             - "node_modules"
       - store_test_results:
           path: test_reports
-  linux_pack_32:
-    docker:
-      - image: gpmdp/build-32
-    steps:
-      - checkout
-      - restore_cache:
-          key: linux-modules-{{ .Branch }}-{{ .Revision }}
-      - run:
-          name: Package
-          command: yarn package:linux:32
-      - save_cache:
-          key: linux-packaged-32-{{ .Branch }}-{{ .Revision }}
-          paths:
-            - "dist"
   linux_pack_64:
     docker:
       - image: gpmdp/build-64
@@ -98,38 +84,6 @@ jobs:
           key: linux-packaged-64-{{ .Branch }}-{{ .Revision }}
           paths:
             - "dist"
-  linux_deb_32:
-    docker:
-      - image: gpmdp/build-32
-    steps:
-      - checkout
-      - restore_cache:
-          key: linux-modules-{{ .Branch }}-{{ .Revision }}
-      - restore_cache:
-          key: linux-packaged-32-{{ .Branch }}-{{ .Revision }}
-      - run:
-          name: Make
-          command: GPMDP_SKIP_PACKAGE=true yarn make:deb:32
-      - save_cache:
-          key: linux-artifact-deb-32-{{ .Branch }}-{{ .Revision }}
-          paths:
-            - "dist/installers"
-  linux_rpm_32:
-    docker:
-      - image: gpmdp/build-32
-    steps:
-      - checkout
-      - restore_cache:
-          key: linux-modules-{{ .Branch }}-{{ .Revision }}
-      - restore_cache:
-          key: linux-packaged-32-{{ .Branch }}-{{ .Revision }}
-      - run:
-          name: Make
-          command: GPMDP_SKIP_PACKAGE=true yarn make:rpm:32
-      - save_cache:
-          key: linux-artifact-rpm-32-{{ .Branch }}-{{ .Revision }}
-          paths:
-            - "dist/installers"
   linux_deb_64:
     docker:
       - image: gpmdp/build-64
@@ -167,10 +121,6 @@ jobs:
       - image: gpmdp/build-64
     steps:
       - restore_cache:
-          key: linux-artifact-deb-32-{{ .Branch }}-{{ .Revision }}
-      - restore_cache:
-          key: linux-artifact-rpm-32-{{ .Branch }}-{{ .Revision }}
-      - restore_cache:
           key: linux-artifact-deb-64-{{ .Branch }}-{{ .Revision }}
       - restore_cache:
           key: linux-artifact-rpm-64-{{ .Branch }}-{{ .Revision }}
@@ -195,18 +145,9 @@ workflows:
     jobs:
       - darwin
       - linux_test
-      - linux_pack_32:
-          requires:
-            - linux_test
       - linux_pack_64:
           requires:
             - linux_test
-      - linux_deb_32:
-          requires:
-            - linux_pack_32
-      - linux_rpm_32:
-          requires:
-            - linux_pack_32
       - linux_deb_64:
           requires:
             - linux_pack_64
@@ -215,8 +156,6 @@ workflows:
             - linux_pack_64
       - artifact_gather:
           requires:
-            - linux_deb_32
-            - linux_rpm_32
             - linux_deb_64
             - linux_rpm_64
             - darwin

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -36,7 +36,7 @@ const paths = {
 const packageJSON = require('./package.json');
 
 let version = packageJSON.devDependencies.electron;
-if (version.substr(0, 1) !== '0' && version.substr(0, 1) !== '1' && version.substr(0, 1) !== '2' && version.substr(0, 1) !== '3') {
+if (isNaN(version.charAt(0))) {
   version = version.substr(1);
 }
 

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "coveralls": "^2.11.12",
     "cross-env": "^2.0.1",
     "devtron": "^1.0.1",
-    "electron": "3.1.8",
+    "electron": "^4.2.0",
     "electron-devtools-installer": "^2.2.4",
     "electron-mocha": "^3.0.0",
     "electron-packager": "^13.1.1",

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "coveralls": "^2.11.12",
     "cross-env": "^2.0.1",
     "devtron": "^1.0.1",
-    "electron": "^4.2.0",
+    "electron": "4.2.12",
     "electron-devtools-installer": "^2.2.4",
     "electron-mocha": "^3.0.0",
     "electron-packager": "^13.1.1",

--- a/src/renderer/generic/linux/index.js
+++ b/src/renderer/generic/linux/index.js
@@ -1,5 +1,5 @@
-import '../silent_Notification';
 import { remote } from 'electron';
+import '../silent_Notification';
 
 // remote.getCurrentWindow() polyfill?
 if (process.platform === 'linux') {

--- a/src/renderer/generic/linux/index.js
+++ b/src/renderer/generic/linux/index.js
@@ -1,1 +1,9 @@
 import '../silent_Notification';
+import { remote } from 'electron';
+
+// remote.getCurrentWindow() polyfill?
+if (process.platform === 'linux') {
+  if (remote.getCurrentWindow() == null) {
+    remote.getCurrentWindow = () => remote.BrowserWindow.fromId(1);
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -91,9 +91,10 @@
   version "10.3.5"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.3.5.tgz#8423cdf6e6fb83433e489900d7600d3b61c8260c"
 
-"@types/node@^8.0.24":
-  version "8.10.17"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.17.tgz#d48cf10f0dc6dcf59f827f5a3fc7a4a6004318d3"
+"@types/node@^10.12.18":
+  version "10.14.9"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.14.9.tgz#2e8d678039d27943ce53a1913386133227fd9066"
+  integrity sha512-NelG/dSahlXYtSoVPErrp06tYFrvzj8XLWmKA+X8x0W//4MqbUyZu++giUG/v0bjAT6/Qxa8IjodrfdACyb0Fg==
 
 "@types/p-cancelable@^0.3.0":
   version "0.3.0"
@@ -2494,12 +2495,12 @@ electron-windows-store@^0.9.3:
     multiline "^1.0.2"
     path-exists "^3.0.0"
 
-electron@3.1.8:
-  version "3.1.8"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-3.1.8.tgz#01b0b147dfcca47967ff07dbf72bf5e96125a2ac"
-  integrity sha512-1MiFoMzxGaR0wDfwFE5Ydnuk6ry/4lKgF0c+NFyEItxM/WyEHNZPNjJAeKJ+M/0sevmZ+6W4syNZnQL5M3GgsQ==
+electron@^4.2.0:
+  version "4.2.4"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-4.2.4.tgz#68ca7bd4ff2c16b9205549322f0f1cda4ebc9ff9"
+  integrity sha512-d4wEwJluMsRyRgbukLmFVTb6l1J+mc3RLB1ctbpMlSWDFvs+zknPWa+cHBzTWwrdgwINLddr69qsAW1ku6FqYw==
   dependencies:
-    "@types/node" "^8.0.24"
+    "@types/node" "^10.12.18"
     electron-download "^4.1.0"
     extract-zip "^1.0.3"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2495,10 +2495,10 @@ electron-windows-store@^0.9.3:
     multiline "^1.0.2"
     path-exists "^3.0.0"
 
-electron@^4.2.0:
-  version "4.2.4"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-4.2.4.tgz#68ca7bd4ff2c16b9205549322f0f1cda4ebc9ff9"
-  integrity sha512-d4wEwJluMsRyRgbukLmFVTb6l1J+mc3RLB1ctbpMlSWDFvs+zknPWa+cHBzTWwrdgwINLddr69qsAW1ku6FqYw==
+electron@4.2.12:
+  version "4.2.12"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-4.2.12.tgz#8e8926a6a6654cde5eb0612952fed98a56941875"
+  integrity sha512-EES8eMztoW8gEP5E4GQLP8slrfS2jqTYtHbu36mlu3k1xYAaNPyQQr6mCILkYxqj4l3la4CT2Vcs89CUG62vcQ==
   dependencies:
     "@types/node" "^10.12.18"
     electron-download "^4.1.0"


### PR DESCRIPTION
There are quite a few changes with electron 4, and this serves as a starting point for that upgrade. I've fixed what appears to have been broken in electron 4's remote.getCurrentWindow() api returning null during the renderer pre script in linux.

Electron 4 [drops support for 32 bit](https://electronjs.org/blog/linux-32bit-support) packages in linux,~~but this hasn't removed it from the build tooling as of yet.~~