### PR TITLE
fix media key mapping on Linux

### DIFF
--- a/src/main/features/linux/mediaKeysDBus.js
+++ b/src/main/features/linux/mediaKeysDBus.js
@@ -13,17 +13,17 @@ async function registerBindings(desktopEnv, session) {
   };
 
   const legacy = await session.getProxyObject(`org.${desktopEnv}.SettingsDaemon`, `/org/${desktopEnv}/SettingsDaemon/MediaKeys`);
-  legacy.getInterface(`org.${desktopEnv}.SettingsDaemon.MediaKeys`);
-  legacy.on('MediaPlayerKeyPressed', listener);
+  interfaceLegacy = legacy.getInterface(`org.${desktopEnv}.SettingsDaemon.MediaKeys`);
+  interfaceLegacy.on('MediaPlayerKeyPressed', listener);
   app.on('browser-window-focus', () => {
-    legacy.GrabMediaPlayerKeys('GPMDP', 0); // eslint-disable-line
+    interfaceLegacy.GrabMediaPlayerKeys('GPMDP', 0); // eslint-disable-line
   });
 
   const future = await session.getProxyObject(`org.${desktopEnv}.SettingsDaemon.MediaKeys`, `/org/${desktopEnv}/SettingsDaemon/MediaKeys`);
-  future.getInterface(`org.${desktopEnv}.SettingsDaemon.MediaKeys`);
-  future.on('MediaPlayerKeyPressed', listener);
+  interfaceFuture = future.getInterface(`org.${desktopEnv}.SettingsDaemon.MediaKeys`);
+  interfaceFuture.on('MediaPlayerKeyPressed', listener);
   app.on('browser-window-focus', () => {
-    future.GrabMediaPlayerKeys('GPMDP', 0); // eslint-disable-line
+    interfaceFuture.GrabMediaPlayerKeys('GPMDP', 0); // eslint-disable-line
   });
 }
 

--- a/src/main/features/linux/mediaKeysDBus.js
+++ b/src/main/features/linux/mediaKeysDBus.js
@@ -13,14 +13,14 @@ async function registerBindings(desktopEnv, session) {
   };
 
   const legacy = await session.getProxyObject(`org.${desktopEnv}.SettingsDaemon`, `/org/${desktopEnv}/SettingsDaemon/MediaKeys`);
-  interfaceLegacy = legacy.getInterface(`org.${desktopEnv}.SettingsDaemon.MediaKeys`);
+  const interfaceLegacy = legacy.getInterface(`org.${desktopEnv}.SettingsDaemon.MediaKeys`);
   interfaceLegacy.on('MediaPlayerKeyPressed', listener);
   app.on('browser-window-focus', () => {
     interfaceLegacy.GrabMediaPlayerKeys('GPMDP', 0); // eslint-disable-line
   });
 
   const future = await session.getProxyObject(`org.${desktopEnv}.SettingsDaemon.MediaKeys`, `/org/${desktopEnv}/SettingsDaemon/MediaKeys`);
-  interfaceFuture = future.getInterface(`org.${desktopEnv}.SettingsDaemon.MediaKeys`);
+  const interfaceFuture = future.getInterface(`org.${desktopEnv}.SettingsDaemon.MediaKeys`);
   interfaceFuture.on('MediaPlayerKeyPressed', listener);
   app.on('browser-window-focus', () => {
     interfaceFuture.GrabMediaPlayerKeys('GPMDP', 0); // eslint-disable-line


### PR DESCRIPTION
Media keys were not mapped / functioning on Linux.

## CHANGES
- call `GrabMediaPlayerKeys` on the MediaKeys D-Bus interface rather than the `ProxyObject`. This seems to be aligned with the `dbus-next` readme: https://github.com/dbusjs/node-dbus-next#the-client-interface

Tested this on the Ubuntu 18.04 and media keys are now functioning.