### PR TITLE
Fix GPM loading

### DIFF
--- a/src/renderer/windows/GPMWebView/index.js
+++ b/src/renderer/windows/GPMWebView/index.js
@@ -1,6 +1,9 @@
 import _ from 'lodash';
 import { remote } from 'electron';
 
+// Per https://github.com/MarshallOfSound/Google-Play-Music-Desktop-Player-UNOFFICIAL-/issues/3640#issuecomment-543863416
+window.customElements.upgrade = window.customElements.upgrade || function () {};
+
 global.isGPM = true;
 
 require('../../generic');


### PR DESCRIPTION
Uses code from https://github.com/MarshallOfSound/Google-Play-Music-Desktop-Player-UNOFFICIAL-/issues/3640#issuecomment-543863416 to fix the loading bug seen with some cases on GPM.