### PR TITLE
Add a clear button to FileInput to allow custom styles to be cleared

### DIFF
--- a/src/renderer/ui/components/settings/FileInput.js
+++ b/src/renderer/ui/components/settings/FileInput.js
@@ -37,9 +37,13 @@ class FileInput extends Component {
 
   _keyDown = (event) => {
     if (event.which === 27) {
-      this.props.setSetting(this.props.settingsKey, null);
-      this.props.bonusEvents.forEach((eventName) => Emitter.fire(eventName));
+      this._triggerClear();
     }
+  }
+
+  _triggerClear = () => {
+    this.props.setSetting(this.props.settingsKey, null);
+    this.props.bonusEvents.forEach((eventName) => Emitter.fire(eventName));
   }
 
   render() {
@@ -58,6 +62,12 @@ class FileInput extends Component {
           onClick={this._triggerFile}
           onKeyDown={this._keyDown}
         />
+        <RaisedButton
+          onTouchTap={this._triggerClear}
+          style={{ backgroundColor: 'transparent', marginLeft: 14, marginTop: 4, maxHeight: 0, minWidth: 44 }}
+        >
+          <i className="material-icons" style={{ verticalAlign: 'middle' }}>clear</i>
+        </RaisedButton>
       </div>
     );
   }

--- a/test/electron-renderer/ui/FileInput_spec.js
+++ b/test/electron-renderer/ui/FileInput_spec.js
@@ -36,8 +36,8 @@ describe('<FileInput />', () => {
     remote.dialog.showOpenDialog = (bw, opts, cb) => { cb(dummyFileList); callCount++; };
   });
 
-  it('should render a button', () => {
-    component.find('RaisedButton').length.should.be.equal(1);
+  it('should render buttons to select a file and clear', () => {
+    component.find('RaisedButton').length.should.be.equal(2);
   });
 
   it('should render a text input field', () => {
@@ -46,7 +46,8 @@ describe('<FileInput />', () => {
 
   it('should open a file dialog when the button is clicked', () => {
     callCount.should.be.equal(0);
-    component.find('RaisedButton').props().onTouchTap();
+    const button = component.find('RaisedButton').at(0);
+    button.props().onTouchTap();
     callCount.should.be.equal(1);
   });
 
@@ -66,12 +67,20 @@ describe('<FileInput />', () => {
     dummyFileList = [__filename];
     component.find('TextField').props().onClick();
     fired.should.have.property('settings:set');
+    fired['settings:set'].should.deep.equal([[{ key: 'fakeSettingKey', value: __filename }]]);
   });
 
   it('should fire the bonus events when the file exists', () => {
     dummyFileList = [__filename];
     component.find('TextField').props().onClick();
     fired.should.have.property('BonusEvent1');
+  });
+
+  it('should update the correct setting when cleared', () => {
+    const button = component.find('RaisedButton').at(1);
+    button.props().onTouchTap();
+    fired.should.have.property('settings:set');
+    fired['settings:set'].should.deep.equal([[{ key: 'fakeSettingKey', value: null }]]);
   });
 
   afterEach(() => {


### PR DESCRIPTION
Fixes #2031

The `FileInput` component now has a "clear" button that does the same thing that pressing Escape does. I've used a "clear" icon instead of a label to avoid having to add translations.

![image](https://user-images.githubusercontent.com/10321525/68473441-b421e600-026e-11ea-85f0-04023e939ff2.png)
