### PR TITLE
Handle gulp errors to prevent watch tasks hanging on errors

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -177,6 +177,21 @@ const windowsSignFile = (filePath, signDigest) =>
     );
   });
 
+function handleError(err) {
+  // Print the plugin that the error came from so that you don't
+  // have to go searching through the error message to find it.
+  if (err.plugin) {
+    console.error(`Error in '${err.plugin}':`); // eslint-disable-line
+  }
+
+  console.error(err); // eslint-disable-line
+
+  // We *must* emit 'end', otherwise, when watching, the task
+  // will never repeat. Note that this function is not an
+  // arrow function so that the correct `this` is used here.
+  this.emit('end');
+}
+
 gulp.task('clean', cleanGlob(['./build', './dist']));
 gulp.task('clean-dist-win', cleanGlob(`./dist/${packageJSON.productName}-win32-ia32`));
 gulp.task('clean-dist-darwin', cleanGlob(`./dist/${packageJSON.productName}-darwin-ia32`));
@@ -197,7 +212,7 @@ gulp.task('html', ['clean-html'], () => {
 gulp.task('transpile', ['clean-internal'], () => {
   return gulp.src(paths.internalScripts)
     .pipe(babel())
-    .on('error', (err) => { console.error(err); }) // eslint-disable-line
+    .on('error', handleError)
     .pipe(replace(/process\.env\.([a-zA-Z_]+)?( |,|;|\))/gi, (envCall, envKey, closer) => {
       return `'${process.env[envKey]}'${closer}`;
     }))
@@ -217,7 +232,7 @@ gulp.task('fonts', ['clean-fonts'], () => {
 gulp.task('less', ['clean-less'], () => {
   return gulp.src(paths.less)
     .pipe(less())
-    .on('error', (err) => { console.error(err); }) // eslint-disable-line
+    .on('error', handleError)
     .pipe(cssmin())
     .pipe(concat('core.css'))
     .pipe(gulp.dest('./build/assets/css'));


### PR DESCRIPTION
If an error occurs during a watch task (for example, in the `less` task), that task won't run again. This can be fixed by emitting `"end"` when handling the error.

Reference: https://stackoverflow.com/a/23973536/4397397

Before this change, the behavior of `yarn watch` was this:

```
D:\Code\GitHub\GPMDP>yarn watch
yarn run v1.19.1
$ gulp watch
[11:10:02] Failed to load external module @babel/register
[11:10:02] Requiring external module babel-register
[11:10:04] Using gulpfile D:\Code\GitHub\GPMDP\gulpfile.babel.js
[11:10:04] Starting 'clean-internal'...
[11:10:04] Starting 'clean-images'...
[11:10:04] Starting 'clean-less'...
[11:10:04] Starting 'clean-fonts'...
[11:10:04] Starting 'clean-html'...
[11:10:04] Starting 'clean-locales'...
[11:10:04] Finished 'clean-less' after 47 ms
[11:10:04] Starting 'less'...
[11:10:04] Finished 'clean-html' after 51 ms
[11:10:04] Starting 'html'...
[11:10:04] Finished 'clean-images' after 64 ms
[11:10:04] Starting 'copy-static-images'...
[11:10:04] Finished 'clean-internal' after 78 ms
[11:10:04] Starting 'transpile'...
[11:10:04] Finished 'clean-fonts' after 68 ms
[11:10:04] Starting 'fonts'...
[11:10:05] Finished 'clean-locales' after 399 ms
[11:10:05] Starting 'locales'...
[11:10:05] Finished 'html' after 351 ms
[11:10:05] Finished 'less' after 872 ms
[11:10:06] Finished 'copy-static-images' after 1.41 s
[11:10:06] Starting 'images'...
[11:10:07] Finished 'locales' after 2.01 s
[11:10:09] Finished 'fonts' after 4.36 s
[11:10:11] Finished 'images' after 5.12 s
[11:10:12] Finished 'transpile' after 7.3 s
[11:10:12] Starting 'build'...
[11:10:12] Finished 'build' after 27 μs
[11:10:12] Starting 'watch'...
[11:10:12] Finished 'watch' after 193 ms
[11:10:17] Starting 'clean-less'...
[11:10:17] Finished 'clean-less' after 5.51 ms
[11:10:17] Starting 'less'...
{ [Error: Properties must be inside selector blocks. They cannot be in the root in file D:\Code\GitHub\GPMDP\src\assets\less\_colors.less line no. 1]
  ...snip...
  __safety: { toString: [Function: bound ] } }
  
<< File saved at this time >>
  
[11:10:33] Starting 'clean-less'...
[11:10:33] Finished 'clean-less' after 2.31 ms

<< File saved at this time >>

[11:10:36] Starting 'clean-less'...
[11:10:36] Finished 'clean-less' after 1.02 ms
```

Notice that only `clean-less` is running when a file changes. `less` does not run again after the error.

With this change, the behavior is:

```
yarn run v1.19.1
$ gulp watch
[11:12:51] Failed to load external module @babel/register
[11:12:51] Requiring external module babel-register
[11:12:53] Using gulpfile D:\Code\GitHub\GPMDP\gulpfile.babel.js
[11:12:53] Starting 'clean-internal'...
[11:12:53] Starting 'clean-images'...
[11:12:53] Starting 'clean-less'...
[11:12:53] Starting 'clean-fonts'...
[11:12:53] Starting 'clean-html'...
[11:12:53] Starting 'clean-locales'...
[11:12:53] Finished 'clean-less' after 17 ms
[11:12:53] Starting 'less'...
[11:12:53] Finished 'clean-html' after 88 ms
[11:12:53] Starting 'html'...
[11:12:53] Finished 'clean-images' after 130 ms
[11:12:53] Starting 'copy-static-images'...
[11:12:53] Finished 'clean-fonts' after 130 ms
[11:12:53] Starting 'fonts'...
[11:12:54] Finished 'clean-locales' after 259 ms
[11:12:54] Starting 'locales'...
[11:12:54] Finished 'html' after 215 ms
[11:12:54] Finished 'less' after 324 ms
[11:12:54] Finished 'clean-internal' after 424 ms
[11:12:54] Starting 'transpile'...
[11:12:54] Finished 'copy-static-images' after 406 ms
[11:12:54] Starting 'images'...
[11:12:56] Finished 'locales' after 2.43 s
[11:12:58] Finished 'fonts' after 4.65 s
[11:12:58] Finished 'images' after 4.6 s
[11:13:01] Finished 'transpile' after 6.93 s
[11:13:01] Starting 'build'...
[11:13:01] Finished 'build' after 30 μs
[11:13:01] Starting 'watch'...
[11:13:01] Finished 'watch' after 197 ms
[11:13:08] Starting 'clean-less'...
[11:13:08] Finished 'clean-less' after 6.83 ms
[11:13:08] Starting 'less'...
Error in 'gulp-less':
{ [Error: Properties must be inside selector blocks. They cannot be in the root in file D:\Code\GitHub\GPMDP\src\assets\less\_colors.less line no. 1]
  ...snip...
  __safety: { toString: [Function: bound ] } }
[11:13:08] Finished 'less' after 21 ms

<< File saved at this time >>

[11:13:19] Starting 'clean-less'...
[11:13:19] Finished 'clean-less' after 1.68 ms
[11:13:19] Starting 'less'...
[11:13:19] Finished 'less' after 141 ms

<< File saved at this time >>

[11:13:37] Starting 'clean-less'...
[11:13:37] Finished 'clean-less' after 5.57 ms
[11:13:37] Starting 'less'...
[11:13:37] Finished 'less' after 123 ms
```

The `less` task now runs again.