### PR TITLE
Micro player

### DIFF
--- a/docs/PlaybackAPI.md
+++ b/docs/PlaybackAPI.md
@@ -16,7 +16,8 @@ sometimes it will be empty when you try to read it.  (This is really rare)
 ## Data Format
 
 The file contains a single JSON object with the following attributes:
-- **playing**: (bool) Whether or not the player is current playing.  This is false when the player is closed.
+- **playing**: (bool) Whether or not the player is currently playing.  This is false when the player is closed.
+- **paused**: (bool) Whether or not the player is currently paused.  This is false when the player is closed.
 - **rating**: (object) A rating object in the format below
 - **repeat**: (string) The current repeat mode *(Values can be found [here](https://github.com/gmusic-utils/gmusic.js#playbackgetrepeat))*
 - **shuffle**: (string) The current shuffle mode *(Values can be found [here](https://github.com/gmusic-utils/gmusic.js#playbackgetshuffle))*

--- a/src/_locales/cs.json
+++ b/src/_locales/cs.json
@@ -125,6 +125,12 @@
 
   "settings-option-scroll-lyrics": "Posouvat text skladby při přehrávání automaticky",
 
+  "settings-option-micro-buttons-next": "",
+  "settings-option-micro-buttons-play-pause": "",
+  "settings-option-micro-buttons-previous": "",
+  "settings-option-micro-buttons-rating": "",
+  "settings-option-micro-buttons-show-main-window": "",
+
   "settings-option-mini-always-show": "Vždy zobraz informace o skladbě",
   "settings-option-mini-ontop": "Vždy navrchu",
   "settings-option-mini-use-scroll-volume": "Použít rolovací kolečko pro změnu hlasitosti",
@@ -150,6 +156,7 @@
   "title-settings-hotkeys": "Klávesové zkratky",
   "title-settings-lastfm": "LastFM",
   "title-settings-listenbrainz": "ListenBrainz",
+  "title-settings-micro": "",
   "title-settings-mini": "Mini přehrávač",
   "title-settings-style": "Vlastní motivy",
   "title-settings-slack": "",

--- a/src/_locales/cs.json
+++ b/src/_locales/cs.json
@@ -18,6 +18,8 @@
   "label-alarm": "Budík",
   "label-recents": "Nedávno přehráno nebo přidáno",
   "label-desktop-settings": "Nastavení přehrávače",
+  "label-micro-player-on": "",
+  "label-micro-player-off": "",
   "label-donate": "Podpořit",
   "label-help": "Nápověda",
   "label-issues": "Problémy s aplikací",
@@ -51,6 +53,10 @@
   "message-pausing-after-song-button": "Nepozastavovat po této skladbě",
   "message-uncaught-error": "Nastala nespecifikovaná chyba v programu (GPMDP).",
   "message-uncaught-error-button": "Klikněte zde pro nahlášení tohoto problému na GitHub",
+
+  "micro-show-main-window": "",
+  "micro-no-track-message": "",
+  "micro-loading": "",
 
   "modal-confirmTray-title": "Jen abyste věděli",
   "modal-confirmTray-content": "Zavřením hlavního okna programu (to oč jste se právě pokusili) neukončí program, ale pouze jej minimalizuje do systémové lišty. Pokud chcete tuto možnost změnit, můžete tak učinit v okně \"Nastavení Desktop Přehrávače\".",

--- a/src/_locales/da.json
+++ b/src/_locales/da.json
@@ -16,6 +16,8 @@
   "label-alarm": "Alarm",
   "label-recents": "",
   "label-desktop-settings": "Skrivebords indstillinger",
+  "label-micro-player-on": "",
+  "label-micro-player-off": "",
   "label-donate": "Donér",
   "label-help": "Hjælp",
   "label-issues": "Problemer",
@@ -51,6 +53,10 @@
   "message-pausing-after-song-button": "Pause ikke efter denne sang.",
   "message-uncaught-error": "Der er opstået en ukendt fejl i GPMPD.",
   "message-uncaught-error-button": "Klik her for at rapporter denne fejl på GitHub.",
+
+  "micro-show-main-window": "",
+  "micro-no-track-message": "",
+  "micro-loading": "",
 
   "modal-confirmTray-title": "Vær opmærksom på",
   "modal-confirmTray-content": "Hvis man lukker vinduet, vil det minimere til proceslinjen. Du kan ændre dette under \"Skrivebords Indstillinger\".",

--- a/src/_locales/da.json
+++ b/src/_locales/da.json
@@ -125,6 +125,12 @@
 
   "settings-option-scroll-lyrics": "Automatisk rul af sangtekster når der afspilles",
 
+  "settings-option-micro-buttons-next": "",
+  "settings-option-micro-buttons-play-pause": "",
+  "settings-option-micro-buttons-previous": "",
+  "settings-option-micro-buttons-rating": "",
+  "settings-option-micro-buttons-show-main-window": "",
+
   "settings-option-mini-always-show": "Vis altid sang informationer.",
   "settings-option-mini-ontop": "Altid foran",
   "settings-option-mini-use-scroll-volume": "Brug rullehjulet til at justere lydstyrken",
@@ -150,6 +156,7 @@
   "title-settings-hotkeys": "Genveje",
   "title-settings-lastfm": "LastFM",
   "title-settings-listenbrainz": "ListenBrainz",
+  "title-settings-micro": "",
   "title-settings-mini": "Mini Afspiller",
   "title-settings-style": "Tilpas udseende",
   "title-settings-slack": "",

--- a/src/_locales/de.json
+++ b/src/_locales/de.json
@@ -18,6 +18,8 @@
   "label-alarm": "Wecker",
   "label-recents": "Zuletzt angehört",
   "label-desktop-settings": "Desktop-Einstellungen",
+  "label-micro-player-on": "",
+  "label-micro-player-off": "",
   "label-donate": "Spenden",
   "label-help": "Hilfe",
   "label-issues": "Probleme",
@@ -51,6 +53,10 @@
   "message-pausing-after-song-button": "Nicht nach diesem Titel pausieren",
   "message-uncaught-error": "Es gab einen unbekannten Fehler innerhalb von GPMDP.",
   "message-uncaught-error-button": "Klicke hier, um den Fehler bei GitHub zu melden",
+
+  "micro-show-main-window": "",
+  "micro-no-track-message": "",
+  "micro-loading": "",
 
   "modal-confirmTray-title": "Ein kurzer Hinweis",
   "modal-confirmTray-content": "Das Hauptfenster zu schließen (was du gerade versucht hast) wird den Player in den Infobereich minimieren. Um dieses Verhalten zu ändern, gehe in die \"Desktop-Einstellungen\".",

--- a/src/_locales/de.json
+++ b/src/_locales/de.json
@@ -125,6 +125,12 @@
 
   "settings-option-scroll-lyrics": "Liedtext automatisch scrollen",
 
+  "settings-option-micro-buttons-next": "",
+  "settings-option-micro-buttons-play-pause": "",
+  "settings-option-micro-buttons-previous": "",
+  "settings-option-micro-buttons-rating": "",
+  "settings-option-micro-buttons-show-main-window": "",
+
   "settings-option-mini-always-show": "Immer Titelinformationen anzeigen",
   "settings-option-mini-ontop": "Immer im Vordergrund",
   "settings-option-mini-use-scroll-volume": "Mausrad zur Lautstärkekontrolle verwenden",
@@ -150,6 +156,7 @@
   "title-settings-hotkeys": "Hotkeys",
   "title-settings-lastfm": "LastFM",
   "title-settings-listenbrainz": "ListenBrainz",
+  "title-settings-micro": "",
   "title-settings-mini": "Mini-Player",
   "title-settings-style": "Eigene Stile",
   "title-settings-slack": "",

--- a/src/_locales/en-US.json
+++ b/src/_locales/en-US.json
@@ -54,7 +54,7 @@
   "message-uncaught-error": "An uncaught error has occurred inside GPMDP.",
   "message-uncaught-error-button": "Click here to report this as an issue on GitHub",
 
-  "micro-show-main-window": "Show main window",
+  "micro-show-main-window": "Show Main Window",
   "micro-no-track-message": "No song is currently playing",
   "micro-loading": "Getting ready...",
 
@@ -125,6 +125,12 @@
 
   "settings-option-scroll-lyrics": "Scroll lyrics automatically while playing",
 
+  "settings-option-micro-buttons-next": "Show the 'Next Track' button",
+  "settings-option-micro-buttons-play-pause": "Show the 'Play / Pause' button",
+  "settings-option-micro-buttons-previous": "Show the 'Previous Track' button",
+  "settings-option-micro-buttons-rating": "Show the 'Thumbs Up' and 'Thumbs Down' buttons",
+  "settings-option-micro-buttons-show-main-window": "Show the 'Show Main Window' button",
+
   "settings-option-mini-always-show": "Always show song information",
   "settings-option-mini-ontop": "Always on top",
   "settings-option-mini-use-scroll-volume": "Use the scroll wheel to adjust volume",
@@ -151,6 +157,7 @@
   "title-settings-hotkeys": "Hotkeys",
   "title-settings-lastfm": "LastFM",
   "title-settings-listenbrainz": "ListenBrainz",
+  "title-settings-micro": "Micro Player",
   "title-settings-mini": "Mini Player",
   "title-settings-style": "Custom Styles",
   "title-settings-slack": "Slack",

--- a/src/_locales/en-US.json
+++ b/src/_locales/en-US.json
@@ -18,6 +18,8 @@
   "label-alarm": "Alarm",
   "label-recents": "Recents",
   "label-desktop-settings": "Desktop Settings",
+  "label-micro-player-on": "Micro Player On",
+  "label-micro-player-off": "Micro Player Off",
   "label-donate": "Donate",
   "label-help": "Help",
   "label-issues": "Issues",
@@ -51,6 +53,10 @@
   "message-pausing-after-song-button": "Don't pause after this song",
   "message-uncaught-error": "An uncaught error has occurred inside GPMDP.",
   "message-uncaught-error-button": "Click here to report this as an issue on GitHub",
+
+  "micro-show-main-window": "Show main window",
+  "micro-no-track-message": "No song is currently playing",
+  "micro-loading": "Getting ready...",
 
   "modal-confirmTray-title": "Just a heads up",
   "modal-confirmTray-content": "Closing the main player window (what you just tried to do) will actually minimize the player to the System Tray. If you want to change this behaviour it can be changed in the \"Desktop Settings\" window.",

--- a/src/_locales/es-ES.json
+++ b/src/_locales/es-ES.json
@@ -18,6 +18,8 @@
   "label-alarm": "Alarma",
   "label-recents": "Recientes",
   "label-desktop-settings": "Ajustes de escritorio",
+  "label-micro-player-on": "",
+  "label-micro-player-off": "",
   "label-donate": "Donar",
   "label-help": "Ayuda",
   "label-issues": "Problemas",
@@ -51,6 +53,10 @@
   "message-pausing-after-song-button": "No pausar después de esta canción.",
   "message-uncaught-error": "Un error desconocido ha ocurrido con GPMDP.",
   "message-uncaught-error-button": "Haz click aquí para reportar un \"issue\" en GitHub",
+
+  "micro-show-main-window": "",
+  "micro-no-track-message": "",
+  "micro-loading": "",
 
   "modal-confirmTray-title": "Sólo un aviso",
   "modal-confirmTray-content": "Cerrar la ventana principal (lo que acabas de hacer) minimizará la ventana. Si quieres modificar este comportamiento puedes hacerlo en la ventana de \"Ajustes de Escritorio\".",

--- a/src/_locales/es-ES.json
+++ b/src/_locales/es-ES.json
@@ -125,6 +125,12 @@
 
   "settings-option-scroll-lyrics": "Desplazar letra automáticamente mientras suena la canción",
 
+  "settings-option-micro-buttons-next": "",
+  "settings-option-micro-buttons-play-pause": "",
+  "settings-option-micro-buttons-previous": "",
+  "settings-option-micro-buttons-rating": "",
+  "settings-option-micro-buttons-show-main-window": "",
+
   "settings-option-mini-always-show": "Mostrar siempre información de canción",
   "settings-option-mini-ontop": "Siempre visible",
   "settings-option-mini-use-scroll-volume": "Usa la rueda del ratón para ajustar el volumen",
@@ -150,6 +156,7 @@
   "title-settings-hotkeys": "Atajos",
   "title-settings-lastfm": "LastFM",
   "title-settings-listenbrainz": "ListenBrainz",
+  "title-settings-micro": "",
   "title-settings-mini": "Mini Player",
   "title-settings-style": "Estilos",
   "title-settings-slack": "Slack",

--- a/src/_locales/fr-FR.json
+++ b/src/_locales/fr-FR.json
@@ -125,6 +125,12 @@
 
   "settings-option-scroll-lyrics": "Défilement automatique des paroles",
 
+  "settings-option-micro-buttons-next": "",
+  "settings-option-micro-buttons-play-pause": "",
+  "settings-option-micro-buttons-previous": "",
+  "settings-option-micro-buttons-rating": "",
+  "settings-option-micro-buttons-show-main-window": "",
+
   "settings-option-mini-always-show": "Toujours montrer les informations du morceau",
   "settings-option-mini-ontop": "Toujours au dessus",
   "settings-option-mini-use-scroll-volume": "Utiliser la molette de la souris pour ajuster le volume",
@@ -151,6 +157,7 @@
   "title-settings-hotkeys": "Raccourcis",
   "title-settings-lastfm": "LastFM",
   "title-settings-listenbrainz": "ListenBrainz",
+  "title-settings-micro": "",
   "title-settings-mini": "Mini Lecteur",
   "title-settings-style": "Styles Personnalisés",
   "title-settings-slack": "Slack",

--- a/src/_locales/fr-FR.json
+++ b/src/_locales/fr-FR.json
@@ -18,6 +18,8 @@
   "label-alarm": "Alarme",
   "label-recents": "Récents",
   "label-desktop-settings": "Paramètres logiciel",
+  "label-micro-player-on": "",
+  "label-micro-player-off": "",
   "label-donate": "Donation",
   "label-help": "Aide",
   "label-issues": "Problèmes",
@@ -51,6 +53,10 @@
   "message-pausing-after-song-button": "Ne pas mettre en pause après ce morceau",
   "message-uncaught-error": "Une erreur est survenu dans GPMDP.",
   "message-uncaught-error-button": "Cliquez-ici pour reporter l'erreur sur GitHub",
+
+  "micro-show-main-window": "",
+  "micro-no-track-message": "",
+  "micro-loading": "",
 
   "modal-confirmTray-title": "Juste un avertissement",
   "modal-confirmTray-content": "Fermer la fenêtre principale (ce que vous essayez de faire) va minimiser le lecteur dans le système de notifications. Ce comportement peut être changé dans la fenêtre \"Paramètres du logiciel\".",

--- a/src/_locales/hu.json
+++ b/src/_locales/hu.json
@@ -125,6 +125,12 @@
 
   "settings-option-scroll-lyrics": "Zeneszám lejátszása közben automatikusan görgesse a dalszöveget",
 
+  "settings-option-micro-buttons-next": "",
+  "settings-option-micro-buttons-play-pause": "",
+  "settings-option-micro-buttons-previous": "",
+  "settings-option-micro-buttons-rating": "",
+  "settings-option-micro-buttons-show-main-window": "",
+
   "settings-option-mini-always-show": "Mindig mutassa a dal információit",
   "settings-option-mini-ontop": "Mindig tartsa fent az ablakot",
   "settings-option-mini-use-scroll-volume": "Használja az egér görgetőjét a hangerő beállításához",
@@ -150,6 +156,7 @@
   "title-settings-hotkeys": "Billentyűparancsok",
   "title-settings-lastfm": "LastFM",
   "title-settings-listenbrainz": "ListenBrainz",
+  "title-settings-micro": "",
   "title-settings-mini": "Mini Lejátszó",
   "title-settings-style": "Egyéni stílusok",
   "title-settings-slack": "",

--- a/src/_locales/hu.json
+++ b/src/_locales/hu.json
@@ -18,6 +18,8 @@
   "label-alarm": "Ébresztő",
   "label-recents": "Legutóbbiak",
   "label-desktop-settings": "Asztali beállítások",
+  "label-micro-player-on": "",
+  "label-micro-player-off": "",
   "label-donate": "Adomány",
   "label-help": "Segítség",
   "label-issues": "Problémák",
@@ -51,6 +53,10 @@
   "message-pausing-after-song-button": "Ne szüneteltessen a zeneszám után",
   "message-uncaught-error": "Egy ismeretlen hiba történt a GPMDP-ben.",
   "message-uncaught-error-button": "Kattintson ide, hogy jelentse ezt problémaként a GitHub-on",
+
+  "micro-show-main-window": "",
+  "micro-no-track-message": "",
+  "micro-loading": "",
 
   "modal-confirmTray-title": "Felhívás",
   "modal-confirmTray-content": "Az \"X\" gomb kattintásával valójában nem zárja be az alkalmazást, hanem kis méretre állítja a rendszertálcán . Az  \"Asztali beállítások \" -nál lehetősége van módosítani ezt a beállítást.",

--- a/src/_locales/it.json
+++ b/src/_locales/it.json
@@ -18,6 +18,8 @@
   "label-alarm": "Allarme",
   "label-recents": "Recenti",
   "label-desktop-settings": "Impostazioni desktop",
+  "label-micro-player-on": "",
+  "label-micro-player-off": "",
   "label-donate": "Donazione",
   "label-help": "Aiuto",
   "label-issues": "Problemi",
@@ -51,6 +53,10 @@
   "message-pausing-after-song-button": "Non mettere in pausa dopo questo brano",
   "message-uncaught-error": "Si è verificato un errore in GPMDP.",
   "message-uncaught-error-button": "Clicca qui per riportare l'errore su GitHub",
+
+  "micro-show-main-window": "",
+  "micro-no-track-message": "",
+  "micro-loading": "",
 
   "modal-confirmTray-title": "Un nota al volo",
   "modal-confirmTray-content": "La chiusura della finestra principale (quello che hai appena provato a fare) minimizzerà il lettore nell'area di notifica. Questo comportamento può essere cambiato nella finestra \"Impostazioni desktop\".",

--- a/src/_locales/it.json
+++ b/src/_locales/it.json
@@ -125,6 +125,12 @@
 
   "settings-option-scroll-lyrics": "Scorri automaticamente i testi durante la riproduzione",
 
+  "settings-option-micro-buttons-next": "",
+  "settings-option-micro-buttons-play-pause": "",
+  "settings-option-micro-buttons-previous": "",
+  "settings-option-micro-buttons-rating": "",
+  "settings-option-micro-buttons-show-main-window": "",
+
   "settings-option-mini-always-show": "Mostra sempre le informazioni del brano",
   "settings-option-mini-ontop": "Sempre in primo piano",
   "settings-option-mini-use-scroll-volume": "Usa la rotella di scorrimento per regolare il volume",
@@ -150,6 +156,7 @@
   "title-settings-hotkeys": "Tasti veloci",
   "title-settings-lastfm": "LastFM",
   "title-settings-listenbrainz": "ListenBrainz",
+  "title-settings-micro": "",
   "title-settings-mini": "Mini Player",
   "title-settings-style": "Stili personalizzati",
   "title-settings-slack": "Slack",

--- a/src/_locales/ja.json
+++ b/src/_locales/ja.json
@@ -125,6 +125,12 @@
 
   "settings-option-scroll-lyrics": "再生中に歌詞を自動でスクロールする",
 
+  "settings-option-micro-buttons-next": "",
+  "settings-option-micro-buttons-play-pause": "",
+  "settings-option-micro-buttons-previous": "",
+  "settings-option-micro-buttons-rating": "",
+  "settings-option-micro-buttons-show-main-window": "",
+
   "settings-option-mini-always-show": "常に曲の情報を表示する",
   "settings-option-mini-ontop": "常に最前面に表示する",
   "settings-option-mini-use-scroll-volume": "音量調節にスクロールホイールを利用する",
@@ -150,6 +156,7 @@
   "title-settings-hotkeys": "ホットキー",
   "title-settings-lastfm": "LastFM",
   "title-settings-listenbrainz": "ListenBrainz",
+  "title-settings-micro": "",
   "title-settings-mini": "ミニプレーヤー",
   "title-settings-style": "カスタムスタイル",
   "title-settings-slack": "Slack",

--- a/src/_locales/ja.json
+++ b/src/_locales/ja.json
@@ -18,6 +18,8 @@
   "label-alarm": "アラーム",
   "label-recents": "履歴",
   "label-desktop-settings": "デスクトップ設定",
+  "label-micro-player-on": "",
+  "label-micro-player-off": "",
   "label-donate": "寄付",
   "label-help": "ヘルプ",
   "label-issues": "Issues",
@@ -51,6 +53,10 @@
   "message-pausing-after-song-button": "この曲の後で一時停止しない",
   "message-uncaught-error": "想定外のエラーが発生しました",
   "message-uncaught-error-button": "この問題をGitHubで報告するにはここをクリック",
+
+  "micro-show-main-window": "",
+  "micro-no-track-message": "",
+  "micro-loading": "",
 
   "modal-confirmTray-title": "お知らせ",
   "modal-confirmTray-content": "メインプレーヤーのウィンドウを閉じると、プレーヤーシステムトレイに最小化されます。この動作を変更したい場合は「デスクトップ設定」ウィンドウで変更できます",

--- a/src/_locales/ka.json
+++ b/src/_locales/ka.json
@@ -18,6 +18,8 @@
   "label-alarm": "მაღვიძარა",
   "label-recents": "ბოლოს",
   "label-desktop-settings": "პროგრამის პარამეტრები",
+  "label-micro-player-on": "",
+  "label-micro-player-off": "",
   "label-donate": "დაეხმარე პროექტს",
   "label-help": "დახმარება",
   "label-issues": "პრობლემები",
@@ -51,6 +53,10 @@
   "message-pausing-after-song-button": "არ დაპაუზდეს ამ კომპოზიციის შემდეგ",
   "message-uncaught-error": "GPMDP-ში მოხდა შეცდომა.",
   "message-uncaught-error-button": "დააკლიკეთ აქ რათა ეს შეცდომა გაიგზავნოს GitHub-ზე",
+
+  "micro-show-main-window": "",
+  "micro-no-track-message": "",
+  "micro-loading": "",
 
   "modal-confirmTray-title": "უბრალოდ შეხსენება",
   "modal-confirmTray-content": "მთავარი ფლეერის ფანჯრის დახურვა (რაც ეხლა გააკეთეთ) კეცავს პროგრამას თრეიში. ამის შეცვლა შეგიძლიათ მენიუში \"პროგრამის პარამეტრები\".",

--- a/src/_locales/ka.json
+++ b/src/_locales/ka.json
@@ -125,6 +125,12 @@
 
   "settings-option-scroll-lyrics": "სიმღერის ტექსტი დაისქროლოს ავტომატურად",
 
+  "settings-option-micro-buttons-next": "",
+  "settings-option-micro-buttons-play-pause": "",
+  "settings-option-micro-buttons-previous": "",
+  "settings-option-micro-buttons-rating": "",
+  "settings-option-micro-buttons-show-main-window": "",
+
   "settings-option-mini-always-show": "ყოველთვის აჩვენე სიმღერის ინფორმაცია",
   "settings-option-mini-ontop": "იყოს მუდამ წინა პლანზე",
   "settings-option-mini-use-scroll-volume": "ხმის მართვა მაუსის სქროლით",
@@ -151,6 +157,7 @@
   "title-settings-hotkeys": "Hotkeys",
   "title-settings-lastfm": "LastFM",
   "title-settings-listenbrainz": "ListenBrainz",
+  "title-settings-micro": "",
   "title-settings-mini": "მინი ფლეერი",
   "title-settings-style": "საკუთარი სტილები",
   "title-settings-slack": "Slack",

--- a/src/_locales/ko-KR.json
+++ b/src/_locales/ko-KR.json
@@ -18,6 +18,8 @@
   "label-alarm": "알람",
   "label-recents": "최근 항목",
   "label-desktop-settings": "데스크탑 설정",
+  "label-micro-player-on": "",
+  "label-micro-player-off": "",
   "label-donate": "도네이션",
   "label-help": "도움말",
   "label-issues": "이슈",
@@ -51,6 +53,10 @@
   "message-pausing-after-song-button": "일시정지 취소",
   "message-uncaught-error": "GPMDP 내부에서 예치기 못한 오류가 발생하였습니다.",
   "message-uncaught-error-button": "GitHub에 오류에 대해 보고하려면 여기를 클릭하십시오.",
+
+  "micro-show-main-window": "",
+  "micro-no-track-message": "",
+  "micro-loading": "",
 
   "modal-confirmTray-title": "알림",
   "modal-confirmTray-content": "주 플레이어 창을 닫으면 플레이어가 시스템 트레이로 최소화됩니다. 이 동작을 변경하려면 \"데스크탑 설정\"창에서 변경할 수 있습니다.",

--- a/src/_locales/ko-KR.json
+++ b/src/_locales/ko-KR.json
@@ -125,6 +125,12 @@
 
   "settings-option-scroll-lyrics": "재생중에 가사 자동으로 스크롤하기",
 
+  "settings-option-micro-buttons-next": "",
+  "settings-option-micro-buttons-play-pause": "",
+  "settings-option-micro-buttons-previous": "",
+  "settings-option-micro-buttons-rating": "",
+  "settings-option-micro-buttons-show-main-window": "",
+
   "settings-option-mini-always-show": "항상 음악 정보 보여주기",
   "settings-option-mini-ontop": "항상 위에",
   "settings-option-mini-use-scroll-volume": "마우스 스크롤로 볼륨 조절",
@@ -151,6 +157,7 @@
   "title-settings-hotkeys": "단축키",
   "title-settings-lastfm": "LastFM",
   "title-settings-listenbrainz": "ListenBrainz",
+  "title-settings-micro": "",
   "title-settings-mini": "미니 플레이어",
   "title-settings-style": "커스텀 스타일",
   "title-settings-slack": "Slack",

--- a/src/_locales/nl-NL.json
+++ b/src/_locales/nl-NL.json
@@ -18,6 +18,8 @@
   "label-alarm": "Alarm",
   "label-recents": "Recent",
   "label-desktop-settings": "Desktop-instellingen",
+  "label-micro-player-on": "",
+  "label-micro-player-off": "",
   "label-donate": "Doneren",
   "label-help": "Help",
   "label-issues": "Problemen",
@@ -51,6 +53,10 @@
   "message-pausing-after-song-button": "Niet pauzeren na dit nummer",
   "message-uncaught-error": "Er is een onverwachte fout opgetreden in GPMDP.",
   "message-uncaught-error-button": "Klik hier om dit op Github te rapporteren als een probleem",
+
+  "micro-show-main-window": "",
+  "micro-no-track-message": "",
+  "micro-loading": "",
 
   "modal-confirmTray-title": "Een korte waarschuwing",
   "modal-confirmTray-content": "Afsluiten van het hoofdvenster van de speler (wat u net probeerde te doen) zal in feite de speler minimaliseren naar het systeemvak. Als u dit gedrag wilt veranderen, kan dat in het venster \"Desktop-instellingen\".",

--- a/src/_locales/nl-NL.json
+++ b/src/_locales/nl-NL.json
@@ -125,6 +125,12 @@
 
   "settings-option-scroll-lyrics": "Liedteksten automatisch scrollen tijdens het afspelen",
 
+  "settings-option-micro-buttons-next": "",
+  "settings-option-micro-buttons-play-pause": "",
+  "settings-option-micro-buttons-previous": "",
+  "settings-option-micro-buttons-rating": "",
+  "settings-option-micro-buttons-show-main-window": "",
+
   "settings-option-mini-always-show": "Altijd informatie over het nummer tonen",
   "settings-option-mini-ontop": "Altijd op de voorgrond",
   "settings-option-mini-use-scroll-volume": "Gebruik het muiswieltje om het volume aan te passen",
@@ -151,6 +157,7 @@
   "title-settings-hotkeys": "Sneltoetsen",
   "title-settings-lastfm": "LastFM",
   "title-settings-listenbrainz": "ListenBrainz",
+  "title-settings-micro": "",
   "title-settings-mini": "Mini-speler",
   "title-settings-style": "Stylesheets",
   "title-settings-slack": "Slack",

--- a/src/_locales/pirate.json
+++ b/src/_locales/pirate.json
@@ -18,6 +18,8 @@
   "label-alarm": "",
   "label-recents": "",
   "label-desktop-settings": "Change ye settings",
+  "label-micro-player-on": "",
+  "label-micro-player-off": "",
   "label-donate": "Share some 'o ye plunder",
   "label-help": "Lend me some assistance",
   "label-issues": "Somethin' bad be happenin'",
@@ -51,6 +53,10 @@
   "message-pausing-after-song-button": "Don't pause after 'tis song",
   "message-uncaught-error": "GPMDP 'as caught ye an error.",
   "message-uncaught-error-button": "Click here to report 'tis 'ere' issue on GitHub",
+
+  "micro-show-main-window": "",
+  "micro-no-track-message": "",
+  "micro-loading": "",
 
   "modal-confirmTray-title": "Ahoy",
   "modal-confirmTray-content": "Closin' th' main player window (what ye just tried to do) gunna actually minimize th' player to th' System Tray. If ye want to change 'tis behaviour it can be changed in th' \"Desktop Settin's\" window.",

--- a/src/_locales/pirate.json
+++ b/src/_locales/pirate.json
@@ -125,6 +125,12 @@
 
   "settings-option-scroll-lyrics": "",
 
+  "settings-option-micro-buttons-next": "",
+  "settings-option-micro-buttons-play-pause": "",
+  "settings-option-micro-buttons-previous": "",
+  "settings-option-micro-buttons-rating": "",
+  "settings-option-micro-buttons-show-main-window": "",
+
   "settings-option-mini-always-show": "Always be showin' song information",
   "settings-option-mini-ontop": "Always keep this 'ere application on top'",
   "settings-option-mini-use-scroll-volume": "",
@@ -150,6 +156,7 @@
   "title-settings-hotkeys": "Magic Buttons",
   "title-settings-lastfm": "LastFM",
   "title-settings-listenbrainz": "ListenBrainz",
+  "title-settings-micro": "",
   "title-settings-mini": "Small Player",
   "title-settings-style": "Custom ship",
   "title-settings-slack": "",

--- a/src/_locales/pl-PL.json
+++ b/src/_locales/pl-PL.json
@@ -18,6 +18,8 @@
   "label-alarm": "Budzik",
   "label-recents": "Ostatnie",
   "label-desktop-settings": "Ustawienia aplikacji",
+  "label-micro-player-on": "",
+  "label-micro-player-off": "",
   "label-donate": "Wspomóż projekt",
   "label-help": "Pomoc",
   "label-issues": "Problemy",
@@ -51,6 +53,10 @@
   "message-pausing-after-song-button": "Wyłączono wstrzymanie po tym utworze",
   "message-uncaught-error": "Wystąpił niespodziewany błąd w aplikacji GPMDP.",
   "message-uncaught-error-button": "Kliknij tutaj aby zgłosić ten błąd na stronie GitHub",
+
+  "micro-show-main-window": "",
+  "micro-no-track-message": "",
+  "micro-loading": "",
 
   "modal-confirmTray-title": "Chcieliśmy tylko uprzedzić",
   "modal-confirmTray-content": "Zamknięcie głównego okna aplikacji (czyli to, co właśnie próbowałeś zrobić) w rzeczywistości zminimalizuje odtwarzacz do systemowego paska narzędzi. Możesz zmienić to ustawienie w oknie Ustawień Aplikacji.",

--- a/src/_locales/pl-PL.json
+++ b/src/_locales/pl-PL.json
@@ -125,6 +125,12 @@
 
   "settings-option-scroll-lyrics": "Przewijaj napisy automatycznie podczas odtwarzania",
 
+  "settings-option-micro-buttons-next": "",
+  "settings-option-micro-buttons-play-pause": "",
+  "settings-option-micro-buttons-previous": "",
+  "settings-option-micro-buttons-rating": "",
+  "settings-option-micro-buttons-show-main-window": "",
+
   "settings-option-mini-always-show": "Zawsze pokazuj informacje o utworze",
   "settings-option-mini-ontop": "Zawsze na wierzchu",
   "settings-option-mini-use-scroll-volume": "Użyj rolki myszki aby sterować głośnością",
@@ -150,6 +156,7 @@
   "title-settings-hotkeys": "Skróty klawiszowe",
   "title-settings-lastfm": "LastFM",
   "title-settings-listenbrainz": "ListenBrainz",
+  "title-settings-micro": "",
   "title-settings-mini": "Mini odtwarzacz",
   "title-settings-style": "Własne style",
   "title-settings-slack": "Slack",

--- a/src/_locales/pt-BR.json
+++ b/src/_locales/pt-BR.json
@@ -18,6 +18,8 @@
   "label-alarm": "Despertador",
   "label-recents": "Recentes",
   "label-desktop-settings": "Configurações desktop",
+  "label-micro-player-on": "",
+  "label-micro-player-off": "",
   "label-donate": "Doar",
   "label-help": "Ajuda",
   "label-issues": "Github Issues",
@@ -51,6 +53,10 @@
   "message-pausing-after-song-button": "Não pause após essa música",
   "message-uncaught-error": "Um erro inesperado ocorreu no GPMDP.",
   "message-uncaught-error-button": "Clique aqui para reportar um problema no Github",
+
+  "micro-show-main-window": "",
+  "micro-no-track-message": "",
+  "micro-loading": "",
 
   "modal-confirmTray-title": "Só um aviso",
   "modal-confirmTray-content": "Fechar a janela principal do Player (como você acabou de fazer) vai minimizá-lo para a bandeja do sistema. Caso queira mudar este comportamento, altere na janela \"Configurações Desktop\"",

--- a/src/_locales/pt-BR.json
+++ b/src/_locales/pt-BR.json
@@ -125,6 +125,12 @@
 
   "settings-option-scroll-lyrics": "Rolar letra automaticamente enquanto executa",
 
+  "settings-option-micro-buttons-next": "",
+  "settings-option-micro-buttons-play-pause": "",
+  "settings-option-micro-buttons-previous": "",
+  "settings-option-micro-buttons-rating": "",
+  "settings-option-micro-buttons-show-main-window": "",
+
   "settings-option-mini-always-show": "Sempre mostrar informações da música",
   "settings-option-mini-ontop": "Sempre no topo",
   "settings-option-mini-use-scroll-volume": "Use o scroll do mouse para controlar o volume",
@@ -150,6 +156,7 @@
   "title-settings-hotkeys": "Atalhos",
   "title-settings-lastfm": "LastFM",
   "title-settings-listenbrainz": "ListenBrainz",
+  "title-settings-micro": "",
   "title-settings-mini": "Mini Player",
   "title-settings-style": "Estilos personalizados",
   "title-settings-slack": "",

--- a/src/_locales/ro.json
+++ b/src/_locales/ro.json
@@ -125,6 +125,12 @@
 
   "settings-option-scroll-lyrics": "Derulează automat versurile în timpul redării",
 
+  "settings-option-micro-buttons-next": "",
+  "settings-option-micro-buttons-play-pause": "",
+  "settings-option-micro-buttons-previous": "",
+  "settings-option-micro-buttons-rating": "",
+  "settings-option-micro-buttons-show-main-window": "",
+
   "settings-option-mini-always-show": "Arată tot timpul informații despre melodie",
   "settings-option-mini-ontop": "Ține fereastra deasupra",
   "settings-option-mini-use-scroll-volume": "Folosește rotița mouse-ului pentru a ajusta volumul",
@@ -150,6 +156,7 @@
   "title-settings-hotkeys": "Scurtături",
   "title-settings-lastfm": "LastFM",
   "title-settings-listenbrainz": "ListenBrainz",
+  "title-settings-micro": "",
   "title-settings-mini": "Player mini",
   "title-settings-style": "Stiluri personalizate",
   "title-settings-slack": "",

--- a/src/_locales/ro.json
+++ b/src/_locales/ro.json
@@ -18,6 +18,8 @@
   "label-alarm": "Alarmă",
   "label-recents": "Recente",
   "label-desktop-settings": "Setări desktop",
+  "label-micro-player-on": "",
+  "label-micro-player-off": "",
   "label-donate": "Donează",
   "label-help": "Ajutor",
   "label-issues": "Probleme",
@@ -51,6 +53,10 @@
   "message-pausing-after-song-button": "Nu pune pauză după această melodie",
   "message-uncaught-error": "GPMDP a întâmpinat o problemă.",
   "message-uncaught-error-button": "Apasă aici pentru a raporta problema pe GitHub",
+
+  "micro-show-main-window": "",
+  "micro-no-track-message": "",
+  "micro-loading": "",
 
   "modal-confirmTray-title": "Doar o idee",
   "modal-confirmTray-content": "Închiderea ferestrei principale a player-ului (ceea ce tocmai ai încercat să faci) va minimiza de fapt aplicația în bara de sistem. Acest comportament poate fi schimbat accesând opțiunea \"Setări desktop\" din meniu.",

--- a/src/_locales/ru.json
+++ b/src/_locales/ru.json
@@ -18,6 +18,8 @@
   "label-alarm": "Будильник",
   "label-recents": "Недавнее",
   "label-desktop-settings": "Настройки программы",
+  "label-micro-player-on": "",
+  "label-micro-player-off": "",
   "label-donate": "Пожертвовать",
   "label-help": "Помощь",
   "label-issues": "Проблемы",
@@ -51,6 +53,10 @@
   "message-pausing-after-song-button": "Не останавливать после этой песни",
   "message-uncaught-error": "В GPMDP произошла неперехваченная ошибка.",
   "message-uncaught-error-button": "Нажмите сюда, чтобы сообщить об этой ошибке на GitHub",
+
+  "micro-show-main-window": "",
+  "micro-no-track-message": "",
+  "micro-loading": "",
 
   "modal-confirmTray-title": "Просто напоминание :)",
   "modal-confirmTray-content": "Закрытие главного окна проигрывателя (то, что вы сейчас сделали) просто сворачивает его в трей. Это поведение может быть изменено в окне \"Настройки программы\".",

--- a/src/_locales/ru.json
+++ b/src/_locales/ru.json
@@ -125,6 +125,12 @@
 
   "settings-option-scroll-lyrics": "Автоматически прокручивать текст песни во время воспроизведения",
 
+  "settings-option-micro-buttons-next": "",
+  "settings-option-micro-buttons-play-pause": "",
+  "settings-option-micro-buttons-previous": "",
+  "settings-option-micro-buttons-rating": "",
+  "settings-option-micro-buttons-show-main-window": "",
+
   "settings-option-mini-always-show": "Всегда показывать информацию о песне",
   "settings-option-mini-ontop": "Всегда наверху",
   "settings-option-mini-use-scroll-volume": "Управление громкостью колесом мыши",
@@ -150,6 +156,7 @@
   "title-settings-hotkeys": "Горячие клавиши",
   "title-settings-lastfm": "Last.FM",
   "title-settings-listenbrainz": "ListenBrainz",
+  "title-settings-micro": "",
   "title-settings-mini": "Миниплеер",
   "title-settings-style": "Свои стили",
   "title-settings-slack": "",

--- a/src/_locales/sk.json
+++ b/src/_locales/sk.json
@@ -125,6 +125,12 @@
 
   "settings-option-scroll-lyrics": "Automaticky posúvať text skladby počas prehrávania",
 
+  "settings-option-micro-buttons-next": "",
+  "settings-option-micro-buttons-play-pause": "",
+  "settings-option-micro-buttons-previous": "",
+  "settings-option-micro-buttons-rating": "",
+  "settings-option-micro-buttons-show-main-window": "",
+
   "settings-option-mini-always-show": "Vždy zobraziť informácie o skladbe",
   "settings-option-mini-ontop": "Vždy na vrchu",
   "settings-option-mini-use-scroll-volume": "Použiť koliesko myši pre nastavenie hlasitosti",
@@ -150,6 +156,7 @@
   "title-settings-hotkeys": "Klávesové skratky",
   "title-settings-lastfm": "LastFM",
   "title-settings-listenbrainz": "ListenBrainz",
+  "title-settings-micro": "",
   "title-settings-mini": "Mini prehrávač",
   "title-settings-style": "Vlastné štýly",
   "title-settings-slack": "",

--- a/src/_locales/sk.json
+++ b/src/_locales/sk.json
@@ -18,6 +18,8 @@
   "label-alarm": "Budík",
   "label-recents": "Nedávne",
   "label-desktop-settings": "Nastavenia programu",
+  "label-micro-player-on": "",
+  "label-micro-player-off": "",
   "label-donate": "Podporiť",
   "label-help": "Pomocník",
   "label-issues": "Problémy",
@@ -51,6 +53,10 @@
   "message-pausing-after-song-button": "Zrušiť pozastavenie po tejto skladbe",
   "message-uncaught-error": "Vyskytla sa nezachytená chyba v GPMDP.",
   "message-uncaught-error-button": "Kliknite sem, pre nahlásenie chyby na GitHub",
+
+  "micro-show-main-window": "",
+  "micro-no-track-message": "",
+  "micro-loading": "",
 
   "modal-confirmTray-title": "Len pre informáciu",
   "modal-confirmTray-content": "Zatvorenie hlavného okna prehrávača (čo ste sa práve pokúsili urobiť) len minimalizuje prehrávač do systémového panela. Ak to chcete zmeniť, môžete tak urobiť v okne \"Nastavenia programu\".",

--- a/src/_locales/sv.json
+++ b/src/_locales/sv.json
@@ -18,6 +18,8 @@
   "label-alarm": "Alarm",
   "label-recents": "",
   "label-desktop-settings": "Skrivbordsinställingar",
+  "label-micro-player-on": "",
+  "label-micro-player-off": "",
   "label-donate": "Donera",
   "label-help": "Hjälp",
   "label-issues": "Problem",
@@ -51,6 +53,10 @@
   "message-pausing-after-song-button": "Pausar inte efter denna låten.",
   "message-uncaught-error": "Der har uppstått ett okänt fel i GPMPD.",
   "message-uncaught-error-button": "Klicka här för att rapportera detta fel på GitHub.",
+
+  "micro-show-main-window": "",
+  "micro-no-track-message": "",
+  "micro-loading": "",
 
   "modal-confirmTray-title": "OBS",
   "modal-confirmTray-content": "När man stänger fönstret minimeras det till aktivitetsfältet. Du kan ändra detta under \"Skrivbordsinställningar\".",

--- a/src/_locales/sv.json
+++ b/src/_locales/sv.json
@@ -125,6 +125,12 @@
 
   "settings-option-scroll-lyrics": "Scrolla låttexter automatiskt under uppspelning",
 
+  "settings-option-micro-buttons-next": "",
+  "settings-option-micro-buttons-play-pause": "",
+  "settings-option-micro-buttons-previous": "",
+  "settings-option-micro-buttons-rating": "",
+  "settings-option-micro-buttons-show-main-window": "",
+
   "settings-option-mini-always-show": "Visa altid låtinformation.",
   "settings-option-mini-ontop": "Altid längst upp",
   "settings-option-mini-use-scroll-volume": "Använd scrollhjulet för att justera volymen",
@@ -150,6 +156,7 @@
   "title-settings-hotkeys": "Genvägar",
   "title-settings-lastfm": "LastFM",
   "title-settings-listenbrainz": "ListenBrainz",
+  "title-settings-micro": "",
   "title-settings-mini": "Miniuppspelare",
   "title-settings-style": "Anpassa utseende",
   "title-settings-slack": "",

--- a/src/_locales/ua.json
+++ b/src/_locales/ua.json
@@ -18,6 +18,8 @@
   "label-alarm": "Будильник",
   "label-recents": "",
   "label-desktop-settings": "Налаштування застосунку",
+  "label-micro-player-on": "",
+  "label-micro-player-off": "",
   "label-donate": "Заохотити",
   "label-help": "Довідка",
   "label-issues": "Помилки",
@@ -51,6 +53,10 @@
   "message-pausing-after-song-button": "Не зупиняти програвання після цїєї пісні",
   "message-uncaught-error": "В GPMDP сталася помилка, яку не вдалося перехопити.",
   "message-uncaught-error-button": "Повідомити про помилку в GitHub",
+
+  "micro-show-main-window": "",
+  "micro-no-track-message": "",
+  "micro-loading": "",
 
   "modal-confirmTray-title": "Повідомлення",
   "modal-confirmTray-content": "Закриття головного вікна програвача (то, що ви тільки що намагалися зробити) насправді мінімізує програвач до системного лотку. Змінити цю поведінку можна у \"Налаштування\".",

--- a/src/_locales/ua.json
+++ b/src/_locales/ua.json
@@ -125,6 +125,12 @@
 
   "settings-option-scroll-lyrics": "Автоматично прокручувати текст пісні під час відтворення",
 
+  "settings-option-micro-buttons-next": "",
+  "settings-option-micro-buttons-play-pause": "",
+  "settings-option-micro-buttons-previous": "",
+  "settings-option-micro-buttons-rating": "",
+  "settings-option-micro-buttons-show-main-window": "",
+
   "settings-option-mini-always-show": "Завжди показувати інформацію про пісню",
   "settings-option-mini-ontop": "Завжди нагорі",
   "settings-option-mini-use-scroll-volume": "Керування гічністю за допомогою коліщатка миши",
@@ -150,6 +156,7 @@
   "title-settings-hotkeys": "Скорочення клавіатури",
   "title-settings-lastfm": "LastFM",
   "title-settings-listenbrainz": "ListenBrainz",
+  "title-settings-micro": "",
   "title-settings-mini": "Мініплеер",
   "title-settings-style": "Власні стилі",
   "title-settings-slack": "",

--- a/src/assets/less/micro_player.less
+++ b/src/assets/less/micro_player.less
@@ -258,17 +258,14 @@
     display: flex;
     flex-direction: row;
     flex-shrink: 0;
-    padding: 0 (@spacing * 2);
+    padding: 0 @spacing;
     background: #ffffff;
 
     > div {
       display: flex;
       flex-direction: row;
       align-items: center;
-
-      &:not(:last-child) {
-        padding-right: @spacing * 2;
-      }
+      padding: 0 @spacing;
     }
 
     button {

--- a/src/assets/less/micro_player.less
+++ b/src/assets/less/micro_player.less
@@ -180,9 +180,12 @@
       }
     }
 
-    // Make the drag handle that sits inside the `.info` element
-    // cover the entire info panel. This will allow you to drag the
-    // window from anywhere except the area where the buttons are.
+    // Make the drag handle that sits inside the `.info` element cover
+    // the entire info panel. This will allow you to drag the window from
+    // anywhere except the area where the buttons are. If we allowed the
+    // drag handle cover the buttons, even if it sits behind the buttons
+    // in z-index, it still prevents the buttons from being clicked, so
+    // we are limited to putting the drag area only over the info area.
     > .micro-drag-handle {
       position: absolute;
       -webkit-app-region: drag;

--- a/src/assets/less/micro_player.less
+++ b/src/assets/less/micro_player.less
@@ -1,0 +1,370 @@
+@import "_colors.less";
+@import "_variables.less";
+
+@border-width: 2px;
+@spacing: 3px;
+@button-active-background: #dedede;
+@button-disabled-color: #e0e0e0;
+@foreground: #212121;
+@foreground-muted: #616161;
+@shadow-size: 8px;
+
+.truncate() {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.shadow-left() {
+  position: relative;
+
+  &::before {
+    // This is roughly equivalent to:
+    //
+    //    box-shadow: 0px 0px @shadow-size rgba(0, 0, 0, 0.4);
+    //
+    // But the shadow is only put on one side of the element.
+    // That box-shadow is what is used on the footer of the main window.
+    background: linear-gradient(to left, rgba(0, 0, 0, 0.16), rgba(0, 0, 0, 0));
+    left: -@shadow-size;
+    display: block;
+    content: '';
+    position: absolute;
+    width: @shadow-size;
+    height: 100%;
+    top: 0;
+  }
+}
+
+.info-display(@display-sm, @display-lg) {
+  .sm {
+    display: @display-sm;
+  }
+
+  .lg {
+    display: @display-lg;
+  }
+}
+
+.button-size(@button-size, @content-size) {
+  width: @button-size;
+  height: @button-size;
+  border-radius: @button-size / 2;
+
+  > i.material-icons {
+    font-size: @content-size;
+  }
+
+  > svg {
+    width: @content-size;
+    height: @content-size;
+  }
+
+   // Make the content of the play/pause
+   // button larger than the other buttons.
+   &.play-pause {
+    > i.material-icons {
+      font-size: min(@button-size, @content-size + 6);
+    }
+   }
+}
+
+.breakpoint-button-size(@breakpoint, @button-size, @content-size) {
+  @media (min-height: @breakpoint) {
+    .button-size(@button-size, @content-size);
+  }
+}
+
+[micro] {
+  display: flex;
+  border: solid @border-width @orange;
+  background: @grey;
+
+  .micro-player {
+    flex: 1;
+    display: flex;
+    flex-direction: row;
+
+    // Set a min-width to allow text to
+    // be truncated inside flex elements.
+    min-width: 0;
+  }
+
+  .info {
+    flex: 1;
+    display: flex;
+    flex-direction: row;
+    line-height: 1.25;
+    color: @foreground;
+
+    // Set a min-width to allow text to
+    // be truncated inside flex elements.
+    min-width: 0;
+
+    // Position relative so that the drag handle can
+    // be positioned over the entire `.info` element.
+    position: relative;
+
+    .no-track-message {
+      .truncate();
+      opacity: 0.5;
+      font-size: 13px;
+      align-self: center;
+      padding: 0 (@spacing * 2);
+
+      // Hide this message by default.
+      display: none;
+    }
+
+    &.no-track {
+      // When there is no current track, hide each of the info groups
+      // elements. We don't hide the whole info element because that
+      // contains the drag handle, which we always want visible, and
+      // the album art, which will be showing a placeholder.
+      .info-group {
+        display: none;
+      }
+
+      // Show the "no track" message instead.
+      .no-track-message {
+        display: block;
+      }
+    }
+
+    .album-art {
+      flex-shrink: 0;
+
+      img {
+        width: 100%;
+      }
+    }
+
+    .info-group {
+      padding: 0 (@spacing * 2);
+
+      // Set a min-width to allow text to
+      // be truncated inside flex elements.
+      min-width: 0;
+    }
+
+    // By default, only the small variant is shown. The medium
+    // variant will be shown above certain window heights.
+    .info-display(block, none);
+
+    .sm {
+      .truncate();
+      align-self: center;
+      font-size: 13px;
+
+      // Use a muted color for the small variant because
+      // the normal color looks too dark in a small space.
+      color: @foreground-muted;
+    }
+
+    .lg {
+      flex: 1;
+      flex-direction: column;
+      justify-content: center;
+      padding-top: @spacing;
+      padding-bottom: @spacing;
+
+      .track {
+        .truncate();
+        font-size: 13px;
+      }
+
+      .artist-album {
+        .truncate();
+        font-size: 11px;
+        color: @foreground-muted;
+      }
+    }
+
+    // Make the drag handle that sits inside the `.info` element
+    // cover the entire info panel. This will allow you to drag the
+    // window from anywhere except the area where the buttons are.
+    > .micro-drag-handle {
+      position: absolute;
+      -webkit-app-region: drag;
+
+      // Inset the element slightly. Because the border of the micro
+      // player is very thin, the resize grip area is also very thin.
+      // By not pushing the drag handle all the way to the edge of the
+      // window, the resize grip area will become a little bit larger.
+      left: 2px;
+      top: 2px;
+      right: 2px;
+      bottom: 2px;
+    }
+
+    .loader-container {
+      flex: 1;
+      display: flex;
+      flex-direction: row;
+      align-items: center;
+
+      // Set a min-width to allow text to
+      // be truncated inside flex elements.
+      min-width: 0;
+
+      .circular {
+        position: static;
+        margin: 0 (@spacing * 4);
+        width: 20px;
+        height: 20px;
+      }
+
+      .loading-label {
+        .truncate();
+        flex: 1;
+        font-size: 12px;
+        color: @foreground-muted;
+      }
+    }
+
+    &:not(.loading) {
+      .loader-container {
+        display: none;
+      }
+    }
+
+    &.loading {
+      // While the application is loading, hide
+      // everything in the info panel except for
+      // the loading indicator and the drag handle.
+      .album-art,
+      .info-group,
+      .no-track-message {
+        display: none;
+      }
+    }
+  }
+
+  .controls {
+    .shadow-left();
+
+    display: flex;
+    flex-direction: row;
+    flex-shrink: 0;
+    padding: 0 (@spacing * 2);
+    background: #ffffff;
+
+    > div {
+      display: flex;
+      flex-direction: row;
+      align-items: center;
+
+      &:not(:last-child) {
+        padding-right: @spacing * 2;
+      }
+    }
+
+    button {
+      background: none;
+      border: none;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 0;
+      user-select: none;
+      color: @foreground;
+      fill: @foreground;
+
+      &.play-pause {
+        color: @orange;
+      }
+
+      &:not([disabled]) {
+        cursor: pointer;
+
+        &:active {
+          background: @button-active-background;
+        }
+
+        &:focus {
+          outline: none;
+        }
+      }
+
+      &[disabled] {
+        color: @button-disabled-color;
+        fill: @button-disabled-color;
+      }
+    }
+  }
+
+  @media (max-height: 26px) {
+    .info {
+      // Hide the album art when the window height is
+      // small because the album art isn't legible.
+      .album-art {
+        display: none;
+      }
+
+      // Reduce the size of the loading indicator.
+      .loader-container {
+        .circular {
+          width: 14px;
+          height: 14px;
+        }
+      }
+
+      // When the window is small, the font looks
+      // like it's bold because it fills the window.
+      // Fix this by reducing the font size.
+      .sm,
+      .no-track-message {
+        font-size: 11px;
+      }
+    }
+  }
+
+  @media (min-height: 36px) {
+    // At this breakpoint and above, there is enough
+    // room to show the info in a larger format.
+    .info {
+      .info-display(none, flex);
+    }
+  }
+
+  // Increase the size of the buttons as the window height increases.
+  // The minimum window height is 20px and there's a two-pixel border,
+  // so the buttons should be 14px high at that minimum height which
+  // ensures there is a one-pixel space above and below the buttons.
+  .controls {
+    button {
+      .button-size(14px, 14px);
+      .breakpoint-button-size(22px, 16px, 14px);
+      .breakpoint-button-size(24px, 18px, 16px);
+      .breakpoint-button-size(26px, 20px, 16px);
+      .breakpoint-button-size(28px, 22px, 16px);
+    }
+  }
+
+  @media (min-height: 46px) {
+    // The text in the info element
+    // can become a bit larger.
+    .info {
+      .lg {
+        .track {
+          font-size: 15px;
+
+          // Because there's more room, add some
+          // space between the track and artist.
+          padding-bottom: @spacing;
+        }
+
+        .artist-album {
+          font-size: 13px;
+        }
+      }
+    }
+
+    // The buttons can also become a bit larger.
+    .controls {
+      button {
+        .button-size(26px, 18px);
+      }
+    }
+  }
+}

--- a/src/assets/less/micro_player.less
+++ b/src/assets/less/micro_player.less
@@ -8,6 +8,10 @@
 @foreground: #212121;
 @foreground-muted: #616161;
 @shadow-size: 8px;
+@dark-foreground: #cccccc;
+@dark-foreground-muted: #959595;
+@dark-button-active-background: #484848;
+@dark-button-disabled-color: #545454;
 
 .truncate() {
   white-space: nowrap;
@@ -77,13 +81,14 @@
 
 #micro-player {
   display: flex;
-  border: solid @border-width @orange;
-  background: @grey;
 
   .micro-player {
     flex: 1;
     display: flex;
     flex-direction: row;
+
+    border: solid @border-width @orange;
+    background: @grey;
 
     // Set a min-width to allow text to
     // be truncated inside flex elements.
@@ -367,6 +372,51 @@
     .controls {
       button {
         .button-size(26px, 18px);
+      }
+    }
+  }
+
+  // Dark theme.
+  .dark {
+    background: @darkprimary;
+
+    .info {
+      color: @dark-foreground;
+
+      .sm {
+        color: @dark-foreground;
+      }
+
+      .lg {
+        .artist-album {
+          color: @dark-foreground-muted;
+        }
+      }
+
+      .loader-container {
+        .loading-label {
+          color: @dark-foreground-muted;
+        }
+      }
+    }
+
+    .controls {
+      background: @darksecondary;
+
+      button {
+        color: @dark-foreground;
+        fill: @dark-foreground;
+
+        &:not([disabled]) {
+          &:active {
+            background: @dark-button-active-background;
+          }
+        }
+
+        &[disabled] {
+          color: @dark-button-disabled-color;
+          fill: @dark-button-disabled-color;
+        }
       }
     }
   }

--- a/src/assets/less/micro_player.less
+++ b/src/assets/less/micro_player.less
@@ -142,6 +142,10 @@
       img {
         width: 100%;
       }
+
+      svg {
+        fill: @orange;
+      }
     }
 
     .info-group {

--- a/src/assets/less/micro_player.less
+++ b/src/assets/less/micro_player.less
@@ -75,7 +75,7 @@
   }
 }
 
-[micro] {
+#micro-player {
   display: flex;
   border: solid @border-width @orange;
   background: @grey;

--- a/src/main/features/core/index.js
+++ b/src/main/features/core/index.js
@@ -18,3 +18,4 @@ import './sleepPreventor';
 import './mediaService';
 import './discordRichPresence';
 import './slack';
+import './microPlayer';

--- a/src/main/features/core/microPlayer/MicroPlayerBoundsManager.js
+++ b/src/main/features/core/microPlayer/MicroPlayerBoundsManager.js
@@ -1,0 +1,162 @@
+import { screen } from 'electron';
+import _ from 'lodash';
+
+const SNAP_THRESHOLD = 5;
+
+/**
+ * Manages the size and position of the micro player window.
+ */
+export class MicroPlayerBoundsManager {
+  /**
+   * @constructor
+   * @param {import('electron').BrowserWindow} window The window to manage.
+   * @param {import('./MicroPlayerSettings').MicroPlayerSettings} settings The settings to use.
+   */
+  constructor(window, settings) {
+    /** @type [string, Function][] */
+    this._listeners = [];
+
+    this._window = window;
+    this._settings = settings;
+
+    const position = this._ensurePositionOnScreen(
+      this._window.getSize(),
+      this._settings.position
+    );
+
+    this._window.setPosition(...position);
+
+    // Debounce save requests so that we don't save
+    // while the window is being moved or resized.
+    const save = _.debounce(() => {
+      this._settings.position = window.getPosition();
+      this._settings.size = window.getSize();
+    }, 1000);
+
+    // Debounce the screen edge snapping. If we snapped to the edge of
+    // the screen on every move event, then you would never be able to
+    // move the window from one display to another when your displays
+    // are laid out vertically. This isn't the ideal behavior but it's
+    // the best we can do given that we are only notified that the window
+    // has moved, and not that it has started or stopped being moved.
+    const snap = _.debounce(() => {
+      this._snapToScreenEdge();
+    }, 250);
+
+    this._addListener('resize', save);
+
+    this._addListener('move', () => {
+      save();
+      snap();
+    });
+
+    // Cancel the debounced functions when the window closes
+    // to prevent those functions operating on a closed window.
+    this._addListener('closed', () => {
+      save.cancel();
+      snap.cancel();
+    });
+  }
+
+  /**
+   *Adds an event listener to the window and records the listener for disposal.
+   * @param {string} event The event name.
+   * @param {Function} listener The event listener to add.
+   */
+  _addListener(event, listener) {
+    this._window.on(event, listener);
+    this._listeners.push([event, listener]);
+  }
+
+  /**
+   * Ensures that the given position is fully on a screen.
+   * @param {[number, number]} size The size of the window.
+   * @param {[number, number] | undefined} position The window position to adjust.
+   * @returns {[number, number]} The adjusted window position.
+   */
+  _ensurePositionOnScreen(size, position) {
+    if (!position) {
+      // There isn't a previous window position, so return a position that will
+      // put the window the top-center of the screen that contains the main window.
+      const mainScreen = screen.getDisplayMatching(
+        WindowManager.getAll('main')[0].getBounds()
+      );
+
+      return [
+        mainScreen.bounds.x + ((mainScreen.bounds.width - size[0]) / 2),
+        mainScreen.bounds.y,
+      ];
+    }
+
+    // Make sure the window is fully on screen. Find the display that the
+    // window is on the most (or the primary display if it's not on any
+    // display), and move the window so that it's fully on that screen.
+    const display = screen.getDisplayMatching({
+      x: position[0],
+      y: position[1],
+      width: size[0],
+      height: size[1],
+    }) || screen.getPrimaryDisplay();
+
+    return [
+      // Make sure the left edge of the window is not
+      // to the left of the display, and the right
+      // edge is not to the right of the display.
+      _.clamp(
+        position[0],
+        display.bounds.x,
+        display.bounds.x + display.bounds.width - size[0]
+      ),
+      // Make sure the top of the window is not above
+      // the top of the display, and the bottom of the
+      // window is not below the bottom of the display.
+      _.clamp(
+        position[1],
+        display.bounds.y,
+        display.bounds.y + display.bounds.height - size[1]
+      ),
+    ];
+  }
+
+  /**
+   * Moves the window so that it touches the top or bottom of the display that
+   * it's primarly on if the window is near to the top or bottom of the display.
+   *
+   * Because the window has a landscape orientation and is designed to be put at the top
+   * or the bottom of the display, no changes are made to the x-coordinate of the window.
+   */
+  _snapToScreenEdge() {
+    const bounds = this._window.getBounds();
+    const display = screen.getDisplayMatching(bounds);
+
+    // If the window has been moved so that part of it is
+    // above the top of the display, then move the window
+    // down so that it's touching the top of the display.
+    const windowTop = bounds.y;
+    const displayTop = display.bounds.y;
+
+    if (windowTop <= (displayTop + SNAP_THRESHOLD)) {
+      this._window.setPosition(bounds.x, displayTop);
+      return;
+    }
+
+    // If the window has been moved so that part of it is
+    // below the bottom of the display, then move the window
+    // up so that it's touching the bottom of the display.
+    const windowBottom = bounds.y + bounds.height;
+    const displayBottom = display.bounds.y + display.bounds.height;
+
+    if (windowBottom >= (displayBottom - SNAP_THRESHOLD)) {
+      this._window.setPosition(bounds.x, displayBottom - bounds.height);
+    }
+  }
+
+  /**
+   * Removes event listeners.
+   */
+  dispose() {
+    this._listeners.forEach(([event, listener]) => {
+      this._window.removeListener(event, listener);
+    });
+  }
+}

--- a/src/main/features/core/microPlayer/MicroPlayerController.js
+++ b/src/main/features/core/microPlayer/MicroPlayerController.js
@@ -4,6 +4,56 @@ import { MicroPlayerEventAdapter } from './MicroPlayerEventAdapter';
 import { MicroPlayerBoundsManager } from './MicroPlayerBoundsManager';
 
 /**
+ * Gets the options for creating the window.
+ * @param {number} width The width of the window.
+ * @param {number} height The height of the window.
+ * @returns {import('electron').BrowserWindowConstructorOptions} The window options.
+ */
+function getWindowOptions(width, height) {
+  return {
+    width,
+    height,
+    minWidth: 160,
+    minHeight: 20,
+    maxHeight: 60,
+    autoHideMenuBar: true,
+    frame: false,
+    hasShadow: false,
+    titleBarStyle: 'hidden',
+    title: 'Google Play Music Desktop Player - Micro Player',
+
+    // Set `thickFrame` to false to allow resizing below a hard limit that's
+    // applied by something when running on Windows. Doesn't have any effect
+    // at the moment because the version of Electon being used is quite old.
+    // (https://github.com/electron/electron/issues/20183).
+    thickFrame: false,
+
+    // Same color as the background color of the
+    // main window when using the default theme.
+    backgroundColor: '#fafafa',
+
+    // Don't show the window yet. It will be shown
+    // after we ensure that it's positioned on screen.
+    show: false,
+
+    // Don't allow the micro player to be closed. It can only
+    // be closed by turning the setting off through the UI.
+    closable: false,
+
+    // The micro player has a maximum size and should always be visible,
+    // so don't allow it to be minimized, maximized or shown full screen.
+    fullscreenable: false,
+    minimizable: false,
+    maximizable: false,
+
+    webPreferences: {
+      nodeIntegration: true,
+      preload: path.resolve(`${__dirname}/../../../../renderer/generic/index.js`),
+    },
+  };
+}
+
+/**
  * Handles opening and closing the micro player.
  */
 export class MicroPlayerController {
@@ -27,58 +77,21 @@ export class MicroPlayerController {
     // Prevent the window from being closed. This prevents the user from
     // being able to close the window without turning the setting off. We will
     // remove this handler before we need to programatically close the window.
-    this._preventClose = (e) => e.preventDefault();
+    this._preventClose = e => e.preventDefault();
     this._window.on('close', this._preventClose);
   }
 
   /**
    * Creates the micro player window.
+   *
+   * Note: Even though it doesn't need to be, this is an instance function to allow
+   * it to be stubbed in unit tests to prevent the window from being created.
    * @returns {BrowserWindow} The window.
    */
   _createWindow(settings) {
     const [width, height] = settings.size;
 
-    const window = new BrowserWindow({
-      width,
-      height,
-      minWidth: 160,
-      minHeight: 20,
-      maxHeight: 60,
-      autoHideMenuBar: true,
-      frame: false,
-      hasShadow: false,
-      titleBarStyle: 'hidden',
-      title: 'Google Play Music Desktop Player - Micro Player',
-
-      // Set `thickFrame` to false to allow resizing below a hard limit that's
-      // applied by something when running on Windows. Doesn't have any effect
-      // at the moment because the version of Electon being used is quite old.
-      // (https://github.com/electron/electron/issues/20183).
-      thickFrame: false,
-
-      // Same color as the background color of the
-      // main window when using the default theme.
-      backgroundColor: '#fafafa',
-
-      // Don't show the window yet. It will be shown
-      // after we ensure that it's positioned on screen.
-      show: false,
-
-      // Don't allow the micro player to be closed. It can only
-      // be closed by turning the setting off through the UI.
-      closable: false,
-
-      // The micro player has a maximum size and should always be visible,
-      // so don't allow it to be minimized, maximized or shown full screen.
-      fullscreenable: false,
-      minimizable: false,
-      maximizable: false,
-
-      webPreferences: {
-        nodeIntegration: true,
-        preload: path.resolve(`${__dirname}/../../../../renderer/generic/index.js`),
-      },
-    });
+    const window = new BrowserWindow(getWindowOptions(width, height));
 
     // Always show the micro player on top because it's designed to be
     // put at the top or bottom of the screen and be always visible.

--- a/src/main/features/core/microPlayer/MicroPlayerController.js
+++ b/src/main/features/core/microPlayer/MicroPlayerController.js
@@ -1,0 +1,112 @@
+import path from 'path';
+import { BrowserWindow } from 'electron';
+import { MicroPlayerEventAdapter } from './MicroPlayerEventAdapter';
+import { MicroPlayerBoundsManager } from './MicroPlayerBoundsManager';
+
+/**
+ * Handles opening and closing the micro player.
+ */
+export class MicroPlayerController {
+  /**
+   * @constructor
+   * @param {import('./MicroPlayerSettings').MicroPlayerSettings} settings The settings to use.
+   */
+  constructor(settings) {
+    this._settings = settings;
+
+    this._window = this._createWindow(settings);
+    this._windowID = WindowManager.add(this._window, 'micro_player');
+
+    this._events = new MicroPlayerEventAdapter(this._windowID);
+    this._bounds = new MicroPlayerBoundsManager(this._window, this._settings);
+
+    // Show the window now that the bounds manager
+    // has ensured it's fully on screen.
+    this._window.showInactive();
+
+    // Prevent the window from being closed. This prevents the user from
+    // being able to close the window without turning the setting off. We will
+    // remove this handler before we need to programatically close the window.
+    this._preventClose = (e) => e.preventDefault();
+    this._window.on('close', this._preventClose);
+  }
+
+  /**
+   * Creates the micro player window.
+   * @returns {BrowserWindow} The window.
+   */
+  _createWindow(settings) {
+    const [width, height] = settings.size;
+
+    const window = new BrowserWindow({
+      width,
+      height,
+      minWidth: 160,
+      minHeight: 20,
+      maxHeight: 60,
+      autoHideMenuBar: true,
+      frame: false,
+      hasShadow: false,
+      titleBarStyle: 'hidden',
+      title: 'Google Play Music Desktop Player - Micro Player',
+
+      // Set `thickFrame` to false to allow resizing below a hard limit that's
+      // applied by something when running on Windows. Doesn't have any effect
+      // at the moment because the version of Electon being used is quite old.
+      // (https://github.com/electron/electron/issues/20183).
+      thickFrame: false,
+
+      // Same color as the background color of the
+      // main window when using the default theme.
+      backgroundColor: '#fafafa',
+
+      // Don't show the window yet. It will be shown
+      // after we ensure that it's positioned on screen.
+      show: false,
+
+      // Don't allow the micro player to be closed. It can only
+      // be closed by turning the setting off through the UI.
+      closable: false,
+
+      // The micro player has a maximum size and should always be visible,
+      // so don't allow it to be minimized, maximized or shown full screen.
+      fullscreenable: false,
+      minimizable: false,
+      maximizable: false,
+
+      webPreferences: {
+        nodeIntegration: true,
+        preload: path.resolve(`${__dirname}/../../../../renderer/generic/index.js`),
+      },
+    });
+
+    // Always show the micro player on top because it's designed to be
+    // put at the top or bottom of the screen and be always visible.
+    // Note: For some reason setting it to be always on top immediately
+    // doesn't work on Linux, but setting it on the next tick does.
+    setTimeout(() => window.setAlwaysOnTop(true), 0);
+
+    window.loadURL(`file://${__dirname}/../../../../public_html/micro_player.html`);
+
+    return window;
+  }
+
+  /**
+   * Closes the window and removes event listeners.
+   */
+  dispose() {
+    // The micro player window is not closable to prevent the user
+    // from closing it without turning the setting off. But when
+    // it's not closable you can't event close it programatically,
+    // so we need to make the window closable before we close it.
+    this._window.setClosable(true);
+
+    // Remove our 'close' event listener that
+    // prevents the window from being closed.
+    this._window.removeListener('close', this._preventClose);
+    WindowManager.close(this._windowID);
+
+    this._events.dispose();
+    this._bounds.dispose();
+  }
+}

--- a/src/main/features/core/microPlayer/MicroPlayerEventAdapter.js
+++ b/src/main/features/core/microPlayer/MicroPlayerEventAdapter.js
@@ -1,0 +1,121 @@
+import { getAppLoaded } from './_applicationState';
+
+/**
+ * Adapter for relaying messages toamd from the micro player window.
+ */
+export class MicroPlayerEventAdapter {
+  /**
+   * @constructor
+   * @param {Symbol} windowID The ID of the micro player window.
+   */
+  constructor(windowID) {
+    /** @type [string, Function][] */
+    this._listeners = [];
+
+    [
+      'playback:isPlaying',
+      'playback:isPaused',
+      'playback:isStopped',
+    ].forEach((event) => {
+      this._addListener(event, (data) => {
+        Emitter.sendToWindow(windowID, event, data);
+      });
+    });
+
+    [
+      'change:track',
+      'change:rating',
+    ].forEach((event) => {
+      PlaybackAPI.on(event, (data) => {
+        Emitter.sendToWindow(windowID, `PlaybackAPI:${event}`, data);
+      });
+    });
+
+    // The micro player can't show the main window itself, so it
+    // has to send a message to get us to show the main window.
+    this._addListener('micro:showMainWindow', () => {
+      this._showMainWindow();
+    });
+
+    // Wait for the micro player window to become ready
+    // before we tell it about the initial playback state.
+    this._addListener('micro:ready', () => {
+      // The micro player will appear in a "loading" state until the `app:loaded`
+      // event is fired. That event is only raised once by the application, so if
+      // we are opening the micro player after that event was fired, then we need
+      // to send that event to the new window so that it stops showing as loading.
+      if (getAppLoaded()) {
+        Emitter.sendToWindow(windowID, 'app:loaded');
+      }
+
+      // Send messages for the initial state, track and rating.
+      Emitter.sendToWindow(windowID, this._getCurrentPlaybackStateEvent());
+      Emitter.sendToWindow(windowID, 'PlaybackAPI:change:rating', PlaybackAPI.getRating());
+      Emitter.sendToWindow(windowID, 'PlaybackAPI:change:track', PlaybackAPI.currentSong());
+    });
+  }
+
+  /**
+   *Adds an event listener to the `Emitter` and records the listener for disposal.
+   * @param {string} event The event name.
+   * @param {Function} listener The event listener to add.
+   */
+  _addListener(event, listener) {
+    Emitter.on(event, listener);
+    this._listeners.push([event, listener]);
+  }
+
+  /**
+   * Gets the event name for the current playback state.
+   * @returns {string} The name of the event.
+   */
+  _getCurrentPlaybackStateEvent() {
+    if (PlaybackAPI.isPlaying()) {
+      return 'playback:isPlaying';
+    }
+
+    if (PlaybackAPI.isPaused()) {
+      return 'playback:isPaused';
+    }
+
+    return 'playback:isStopped';
+  }
+
+  /**
+   * Shows the main window.
+   */
+  _showMainWindow() {
+    const main = WindowManager.getAll('main')[0];
+
+    if (main) {
+      // Make sure the window will be shown in the taskbar. That setting
+      // may have been turned off if the window was minimized or hidden.
+      main.setSkipTaskbar(false);
+
+      if (main.isMinimized()) {
+        // If we just called `show()`, then the window will be shown
+        // but, if the window was maximized before it was minimized,
+        // it will not be maximized again. Calling `restore()` will
+        // return the window to its unminimized state.
+        main.restore();
+      }
+
+      // On Windows, calling `restore()` will also show and
+      // focus the window, but on Linux it won't, so we will
+      // always call `show()`. Also call `focus()` because `show()`
+      // doesn't cause the window to become active in Linux.
+      main.show();
+      main.focus();
+    }
+  }
+
+  /**
+   * Removes all event listeners.
+   */
+  dispose() {
+    this._listeners.forEach(([event, handler]) => {
+      Emitter.removeListener(event, handler);
+    });
+    this._listeners = [];
+  }
+}

--- a/src/main/features/core/microPlayer/MicroPlayerSettings.js
+++ b/src/main/features/core/microPlayer/MicroPlayerSettings.js
@@ -1,0 +1,59 @@
+/**
+ * Settings wrapper for the micro player.
+ */
+export class MicroPlayerSettings {
+  /**
+   * Gets or sets the enabled state of the micro player.
+   * @returns {boolean} The enabled state.
+   */
+  get enabled() {
+    return this._get('enabled', false);
+  }
+
+  set enabled(value) {
+    this._set('enabled', value);
+  }
+
+  /**
+   * Gets or sets the size of the micro player.
+   * @returns {[number, number]} The width and height.
+   */
+  get size() {
+    return this._get('size', [400, 40]);
+  }
+
+  set size(value) {
+    this._set('size', value);
+  }
+
+  /**
+   * Gets or sets the position of the micro player.
+   * @returns {[number, number] | undefined} The x- and y-coordinates or `undefined` if no position has been saved.
+   */
+  get position() {
+    return this._get('position');
+  }
+
+  set position(value) {
+    this._set('position', value);
+  }
+
+  /**
+   * Gets the value of a setting.
+   * @param {string} key The settings key.
+   * @param {any} defaultValue The value to return if the setting is not defined.
+   * @returns {any} The setting value.
+   */
+  _get(key, defaultValue) {
+    return Settings.get(`microplayer-${key}`, defaultValue);
+  }
+
+  /**
+   * Sets the value of a setting.
+   * @param {string} key The settings key.
+   * @param {any} value The value of the setting.
+   */
+  _set(key, value) {
+    Settings.set(`microplayer-${key}`, value);
+  }
+}

--- a/src/main/features/core/microPlayer/_applicationState.js
+++ b/src/main/features/core/microPlayer/_applicationState.js
@@ -1,0 +1,17 @@
+let loaded = false;
+
+/**
+ * Indicates whether the application has finished loading.
+ * @returns {boolean} True if the application has finished loading; otherwise, false.
+ */
+export function getAppLoaded() {
+  return loaded;
+}
+
+/**
+ * Stores whether the application has finished loading.
+ * @param {boolean} value The new value.
+ */
+export function setAppLoaded(value) {
+  loaded = value;
+}

--- a/src/main/features/core/microPlayer/index.js
+++ b/src/main/features/core/microPlayer/index.js
@@ -1,0 +1,42 @@
+import { MicroPlayerController } from './MicroPlayerController';
+import { MicroPlayerSettings } from './MicroPlayerSettings';
+import { setAppLoaded } from './_applicationState';
+
+const settings = new MicroPlayerSettings();
+
+/** @type MicroPlayerController | undefined */
+let controller = undefined;
+
+// Listen for the "app:loaded" event because we need to send it to the
+// micro player if we open the micro player after that event is fired.
+Emitter.on('app:loaded', () => {
+  setAppLoaded(true);
+});
+
+// Listen for the button in the
+// main menu toggling the micro player.
+Emitter.on('window:microplayer', () => {
+  if (controller !== undefined) {
+    controller.dispose();
+    controller = undefined;
+    settings.enabled = false;
+  } else {
+    controller = new MicroPlayerController(settings);
+    settings.enabled = true;
+  }
+});
+
+// Open the micro player at startup
+// if the setting is enabled.
+if (settings.enabled) {
+  controller = new MicroPlayerController(settings);
+}
+
+// Close the micro player when the main window closes. If we leave
+// the micro player open, it will prevent the application from exiting.
+WindowManager.getAll('main')[0].on('closed', () => {
+  if (controller !== undefined) {
+    controller.dispose();
+    controller = undefined;
+  }
+});

--- a/src/main/features/core/microPlayer/index.js
+++ b/src/main/features/core/microPlayer/index.js
@@ -7,11 +7,11 @@ const settings = new MicroPlayerSettings();
 /** @type MicroPlayerController | undefined */
 let controller = undefined;
 
-// Listen for the "app:loaded" event because we need to send it to the
-// micro player if we open the micro player after that event is fired.
-Emitter.on('app:loaded', () => {
-  setAppLoaded(true);
-});
+// Listen for the "app:loaded" and "app:loading" events so that we can track
+// the application state, because we need to send the "app:loaded" event to
+// the micro player if we open the micro player after the application is loaded.
+Emitter.on('app:loaded', () => setAppLoaded(true));
+Emitter.on('app:loading', () => setAppLoaded(false));
 
 // Listen for the button in the
 // main menu toggling the micro player.

--- a/src/main/features/core/microPlayer/index.js
+++ b/src/main/features/core/microPlayer/index.js
@@ -5,7 +5,7 @@ import { setAppLoaded } from './_applicationState';
 const settings = new MicroPlayerSettings();
 
 /** @type MicroPlayerController | undefined */
-let controller = undefined;
+let controller;
 
 // Listen for the "app:loaded" and "app:loading" events so that we can track
 // the application state, because we need to send the "app:loaded" event to

--- a/src/main/utils/Emitter.js
+++ b/src/main/utils/Emitter.js
@@ -76,6 +76,10 @@ class Emitter {
   once(what, fn) {
     ipcMain.once(what, fn);
   }
+
+  removeListener(what, fn) {
+    ipcMain.removeListener(what, fn);
+  }
 }
 
 export default Emitter;

--- a/src/main/utils/PlaybackAPI.js
+++ b/src/main/utils/PlaybackAPI.js
@@ -24,9 +24,9 @@ class PlaybackAPI extends EventEmitter {
       this._setPlaybackSong(details.title, details.artist, details.album, details.albumArt);
     });
 
-    Emitter.on('playback:isPlaying', this._setPlaying.bind(this, true));
-    Emitter.on('playback:isPaused', this._setPlaying.bind(this, false));
-    Emitter.on('playback:isStopped', this._setPlaying.bind(this, false));
+    Emitter.on('playback:isPlaying', this._setState.bind(this, true, false));
+    Emitter.on('playback:isPaused', this._setState.bind(this, false, true));
+    Emitter.on('playback:isStopped', this._setState.bind(this, false, false));
 
     Emitter.on('change:playback-time', (event, timeObj) => this._setTime(timeObj.current, timeObj.total));
     Emitter.on('change:volume', (event, newVolume) => this._setVolume(newVolume));
@@ -45,6 +45,7 @@ class PlaybackAPI extends EventEmitter {
   reset() {
     this.data = {
       playing: false,
+      paused: false,
       song: {
         title: null,
         artist: null,
@@ -99,8 +100,9 @@ class PlaybackAPI extends EventEmitter {
     this._fire('change:library', this._private_data.library);
   }
 
-  _setPlaying(isPlaying) {
+  _setState(isPlaying, isPaused) {
     this.data.playing = isPlaying;
+    this.data.paused = isPaused;
     this._fire('change:state', isPlaying);
     this._save();
   }
@@ -177,6 +179,10 @@ class PlaybackAPI extends EventEmitter {
 
   isPlaying() {
     return this.data.playing;
+  }
+
+  isPaused() {
+    return this.data.paused;
   }
 
   currentRepeat() {

--- a/src/main/utils/_initialSettings.js
+++ b/src/main/utils/_initialSettings.js
@@ -17,4 +17,9 @@ export default {
   lastFMMapThumbToHeart: true,
   service: 'google-play-music',
   spoofUserAgent: true,
+  microButtonsRating: true,
+  microButtonsPrevious: true,
+  microButtonsPlayPause: true,
+  microButtonsNext: true,
+  microButtonsShowMainWindow: true,
 };

--- a/src/public_html/micro_player.html
+++ b/src/public_html/micro_player.html
@@ -4,7 +4,7 @@
   <title>Google Play Music Desktop Player - Micro Player</title>
   <link href="../assets/css/core.css" rel="stylesheet" type="text/css" />
 </head>
-<body micro="micro">
+<body>
   <div id="micro-player" style="height: 100%"></div>
   <script>
   require('../renderer/windows/micro_player');

--- a/src/public_html/micro_player.html
+++ b/src/public_html/micro_player.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html>
+<head>
+  <title>Google Play Music Desktop Player - Micro Player</title>
+  <link href="../assets/css/core.css" rel="stylesheet" type="text/css" />
+</head>
+<body micro="micro">
+  <div id="micro-player" style="height: 100%"></div>
+  <script>
+  require('../renderer/windows/micro_player');
+  </script>
+</body>
+</html>

--- a/src/renderer/ui/components/generic/JoinedText.js
+++ b/src/renderer/ui/components/generic/JoinedText.js
@@ -1,0 +1,31 @@
+import React, { Component, PropTypes } from 'react';
+
+export default class RatingButton extends Component {
+  static propTypes = {
+    className: PropTypes.string,
+    text: PropTypes.arrayOf(PropTypes.string).isRequired,
+    textClassNames: PropTypes.arrayOf(PropTypes.string),
+    separator: PropTypes.string,
+  };
+
+  static defaultProps = {
+    className: '',
+    text: [],
+    textClassNames: [],
+    separator: '\u00a0-\u00a0',
+  };
+
+  render() {
+    const spans = [];
+
+    this.props.text.forEach((text, index) => {
+      if (index > 0) {
+        spans.push(<span className="separator">{this.props.separator}</span>);
+      }
+
+      spans.push(<span className={this.props.textClassNames && this.props.textClassNames[index]}>{text}</span>);
+    });
+
+    return <div className={this.props.className}>{spans}</div>;
+  }
+}

--- a/src/renderer/ui/components/generic/JoinedText.js
+++ b/src/renderer/ui/components/generic/JoinedText.js
@@ -1,6 +1,6 @@
 import React, { Component, PropTypes } from 'react';
 
-export default class RatingButton extends Component {
+export default class JoinedText extends Component {
   static propTypes = {
     className: PropTypes.string,
     text: PropTypes.arrayOf(PropTypes.string).isRequired,
@@ -20,10 +20,10 @@ export default class RatingButton extends Component {
 
     this.props.text.forEach((text, index) => {
       if (index > 0) {
-        spans.push(<span className="separator">{this.props.separator}</span>);
+        spans.push(<span key={`separator-${index}`} className="separator">{this.props.separator}</span>);
       }
 
-      spans.push(<span className={this.props.textClassNames && this.props.textClassNames[index]}>{text}</span>);
+      spans.push(<span key={`text-${index}`} className={this.props.textClassNames && this.props.textClassNames[index]}>{text}</span>);
     });
 
     return <div className={this.props.className}>{spans}</div>;

--- a/src/renderer/ui/components/generic/LoadingSpinner.js
+++ b/src/renderer/ui/components/generic/LoadingSpinner.js
@@ -1,0 +1,19 @@
+import React, { Component, PropTypes } from 'react';
+
+export default class LoadingSpinner extends Component {
+  static propTypes = {
+    size: PropTypes.number,
+  };
+
+  static defaultProps = {
+    size: 2,
+  };
+
+  render() {
+    return (
+      <svg className="circular" viewBox="25 25 50 50">
+        <circle className="path" cx="50" cy="50" r="20" fill="none" strokeWidth={this.props.size} strokeMiterlimit="10" />
+      </svg>
+    );
+  }
+}

--- a/src/renderer/ui/components/generic/RatingButton.js
+++ b/src/renderer/ui/components/generic/RatingButton.js
@@ -1,0 +1,82 @@
+import React, { Component, PropTypes } from 'react';
+
+export default class RatingButton extends Component {
+  static propTypes = {
+    checked: PropTypes.bool.isRequired,
+    disabled: PropTypes.bool,
+    onClick: PropTypes.func.isRequired,
+    translationKey: PropTypes.string.isRequired,
+    type: PropTypes.oneOf(['like', 'dislike']).isRequired,
+  };
+
+  static defaultProps = {
+    disabled: false,
+  };
+
+  _getLikeSvg() {
+    /* eslint-disable max-len */
+    if (this.props.checked) {
+      // https://material.io/resources/icons/?icon=thumb_up&style=baseline
+      return (
+        <svg width="24" height="24" viewBox="0 0 24 24" className="like-checked">
+          <path fill="none" d="M0 0h24v24H0V0z" />
+          <path d="M1 21h4V9H1v12zm22-11c0-1.1-.9-2-2-2h-6.31l.95-4.57.03-.32c0-.41-.17-.79-.44-1.06L14.17 1 7.59 7.59C7.22 7.95 7 8.45 7 9v10c0 1.1.9 2 2 2h9c.83 0 1.54-.5 1.84-1.22l3.02-7.05c.09-.23.14-.47.14-.73v-2z" />
+        </svg>
+      );
+    }
+
+    // https://material.io/resources/icons/?icon=thumb_up&style=outline
+    return (
+      <svg width="24" height="24" viewBox="0 0 24 24" className="like-unchecked">
+        <path fill="none" d="M0 0h24v24H0V0zm0 0h24v24H0V0z" />
+        <path d="M9 21h9c.83 0 1.54-.5 1.84-1.22l3.02-7.05c.09-.23.14-.47.14-.73v-2c0-1.1-.9-2-2-2h-6.31l.95-4.57.03-.32c0-.41-.17-.79-.44-1.06L14.17 1 7.58 7.59C7.22 7.95 7 8.45 7 9v10c0 1.1.9 2 2 2zM9 9l4.34-4.34L12 10h9v2l-3 7H9V9zM1 9h4v12H1z" />
+      </svg>
+    );
+    /* eslint-enable max-len */
+  }
+
+  _getDislikeSvg() {
+    /* eslint-disable max-len */
+    if (this.props.checked) {
+      // https://material.io/resources/icons/?icon=thumb_down&style=baseline
+      return (
+        <svg width="24" height="24" viewBox="0 0 24 24" className="dislike-checked">
+          <path fill="none" d="M0 0h24v24H0z" />
+          <path d="M15 3H6c-.83 0-1.54.5-1.84 1.22l-3.02 7.05c-.09.23-.14.47-.14.73v2c0 1.1.9 2 2 2h6.31l-.95 4.57-.03.32c0 .41.17.79.44 1.06L9.83 23l6.59-6.59c.36-.36.58-.86.58-1.41V5c0-1.1-.9-2-2-2zm4 0v12h4V3h-4z" />
+        </svg>
+      );
+    }
+
+    // https://material.io/resources/icons/?icon=thumb_down&style=outline
+    return (
+      <svg width="24" height="24" viewBox="0 0 24 24" className="dislike-unchecked">
+        <path fill="none" d="M0 0h24v24H0V0zm0 0h24v24H0V0z" />
+        <path d="M15 3H6c-.83 0-1.54.5-1.84 1.22l-3.02 7.05c-.09.23-.14.47-.14.73v2c0 1.1.9 2 2 2h6.31l-.95 4.57-.03.32c0 .41.17.79.44 1.06L9.83 23l6.59-6.59c.36-.36.58-.86.58-1.41V5c0-1.1-.9-2-2-2zm0 12l-4.34 4.34L12 14H3v-2l3-7h9v10zm4-12h4v12h-4z" />
+      </svg>
+    );
+    /* eslint-enable max-len */
+  }
+
+  render() {
+    let icon;
+
+    // "Outline" icons don't exist in the Material Icons font that's
+    // used in the other buttons, so we need to use SVGs here.
+    if (this.props.type === 'like') {
+      icon = this._getLikeSvg();
+    } else {
+      icon = this._getDislikeSvg();
+    }
+
+    return (
+      <button
+        className={this.props.type}
+        onClick={this.props.onClick}
+        disabled={this.props.disabled}
+        title={TranslationProvider.query(this.props.translationKey)}
+      >
+        {icon}
+      </button>
+    );
+  }
+}

--- a/src/renderer/ui/components/settings/tabs/MicroTab.js
+++ b/src/renderer/ui/components/settings/tabs/MicroTab.js
@@ -1,0 +1,18 @@
+import React, { Component } from 'react';
+
+import SettingsTabWrapper from './SettingsTabWrapper';
+import ToggleableOption from '../ToggleableOption';
+
+export default class MicroTab extends Component {
+  render() {
+    return (
+      <SettingsTabWrapper>
+        <ToggleableOption label={TranslationProvider.query('settings-option-micro-buttons-rating')} settingsKey={"microButtonsRating"} default />
+        <ToggleableOption label={TranslationProvider.query('settings-option-micro-buttons-previous')} settingsKey={"microButtonsPrevious"} default />
+        <ToggleableOption label={TranslationProvider.query('settings-option-micro-buttons-play-pause')} settingsKey={"microButtonsPlayPause"} default />
+        <ToggleableOption label={TranslationProvider.query('settings-option-micro-buttons-next')} settingsKey={"microButtonsNext"} default />
+        <ToggleableOption label={TranslationProvider.query('settings-option-micro-buttons-show-main-window')} settingsKey={"microButtonsShowMainWindow"} default />
+      </SettingsTabWrapper>
+    );
+  }
+}

--- a/src/renderer/ui/pages/MicroPlayerPage.js
+++ b/src/renderer/ui/pages/MicroPlayerPage.js
@@ -44,6 +44,23 @@ function showFullWindow() {
   Emitter.fireAtAll('micro:showMainWindow');
 }
 
+function getAlbumArtUrl(track) {
+  let url;
+
+  if (track && track.albumArt) {
+    // YouTube Music will initially use its own URL as the album art,
+    // and since that's not an image URL, a "broken" image is shown
+    // (https://github.com/gmusic-utils/ytmusic.js/issues/13).
+    // Work around this by ignoring the album art if it starts with the
+    // YouTube Music URL so that we use the placeholder image instead.
+    if (!track.albumArt.startsWith('https://music.youtube.com/')) {
+      url = track.albumArt;
+    }
+  }
+
+  return url || ALBUM_ART_PLACEHOLDER;
+}
+
 export default class MicroPlayer extends Component {
   constructor(...args) {
     super(...args);
@@ -90,7 +107,7 @@ export default class MicroPlayer extends Component {
         artist: (track && track.artist) || undefined,
         album: (track && track.album) || undefined,
         track: (track && track.title) || undefined,
-        albumArt: (track && track.albumArt) || ALBUM_ART_PLACEHOLDER,
+        albumArt: getAlbumArtUrl(track),
       });
     });
 

--- a/src/renderer/ui/pages/MicroPlayerPage.js
+++ b/src/renderer/ui/pages/MicroPlayerPage.js
@@ -168,7 +168,7 @@ export default class MicroPlayer extends Component {
           </div>
 
           <div className="loader-container">
-            <LoadingSpinner size="4" />
+            <LoadingSpinner size={4} />
             <div className="loading-label">
               {TranslationProvider.query('micro-loading')}
             </div>

--- a/src/renderer/ui/pages/MicroPlayerPage.js
+++ b/src/renderer/ui/pages/MicroPlayerPage.js
@@ -2,6 +2,20 @@ import React, { Component } from 'react';
 
 const ALBUM_ART_PLACEHOLDER = 'https://www.samuelattard.com/img/gpm_placeholder.jpg';
 
+const INITIAL_STATE = {
+  loading: true,
+  stopped: true,
+  playing: false,
+  thumbsUp: false,
+  thumbsDown: false,
+  hasTrack: false,
+  artist: undefined,
+  album: undefined,
+  track: undefined,
+  albumArt: ALBUM_ART_PLACEHOLDER,
+  albumArtWidth: 0,
+};
+
 export default class MicroPlayer extends Component {
   constructor(...args) {
     super(...args);
@@ -9,19 +23,7 @@ export default class MicroPlayer extends Component {
     /** @type [string, Function][] */
     this._listeners = [];
 
-    this.state = {
-      loading: true,
-      stopped: true,
-      playing: false,
-      thumbsUp: false,
-      thumbsDown: false,
-      hasTrack: false,
-      artist: undefined,
-      album: undefined,
-      track: undefined,
-      albumArt: ALBUM_ART_PLACEHOLDER,
-      albumArtWidth: 0,
-    };
+    this.state = Object.assign({}, INITIAL_STATE);
 
     this._albumArtElement = undefined;
 
@@ -35,6 +37,12 @@ export default class MicroPlayer extends Component {
   }
 
   componentDidMount() {
+    this._listen('app:loading', () => {
+      // Reset everything if the player reloads, which
+      // happens when switching between GPM and YTM modes.
+      this.setState(INITIAL_STATE);
+    });
+
     this._listen('app:loaded', () => {
       this.setState({ loading: false }, () => {
         // The album art is hidden while loading, so once

--- a/src/renderer/ui/pages/MicroPlayerPage.js
+++ b/src/renderer/ui/pages/MicroPlayerPage.js
@@ -1,5 +1,9 @@
 import React, { Component } from 'react';
 
+import LoadingSpinner from '../components/generic/LoadingSpinner';
+import JoinedText from '../components/generic/JoinedText';
+import RatingButton from '../components/generic/RatingButton';
+
 const ALBUM_ART_PLACEHOLDER = 'https://www.samuelattard.com/img/gpm_placeholder.jpg';
 
 const INITIAL_STATE = {
@@ -15,6 +19,30 @@ const INITIAL_STATE = {
   albumArt: ALBUM_ART_PLACEHOLDER,
   albumArtWidth: 0,
 };
+
+function goToPreviousTrack() {
+  Emitter.fireAtGoogle('playback:previousTrack');
+}
+
+function togglePlay() {
+  Emitter.fireAtGoogle('playback:playPause');
+}
+
+function goToNextTrack() {
+  Emitter.fireAtGoogle('playback:nextTrack');
+}
+
+function toggleThumbsUp() {
+  Emitter.fireAtGoogle('playback:toggleThumbsUp');
+}
+
+function toggleThumbsDown() {
+  Emitter.fireAtGoogle('playback:toggleThumbsDown');
+}
+
+function showFullWindow() {
+  Emitter.fireAtAll('micro:showMainWindow');
+}
 
 export default class MicroPlayer extends Component {
   constructor(...args) {
@@ -37,55 +65,33 @@ export default class MicroPlayer extends Component {
   }
 
   componentDidMount() {
-    this._listen('app:loading', () => {
-      // Reset everything if the player reloads, which
-      // happens when switching between GPM and YTM modes.
-      this.setState(INITIAL_STATE);
-    });
+    // Reset everything if the player reloads, which
+    // happens when switching between GPM and YTM modes.
+    this._listen('app:loading', () => this.setState(INITIAL_STATE));
 
     this._listen('app:loaded', () => {
-      this.setState({ loading: false }, () => {
-        // The album art is hidden while loading, so once
-        // the state has been updated, the album art will
-        // be visible, and we'll need to update its width.
-        this._updateAlbumArtWidth();
-      });
+      // The album art is hidden while loading, so once
+      // the state has been updated, the album art will
+      // be visible, and we'll need to update its width.
+      this.setState({ loading: false }, () => this._updateAlbumArtWidth());
     });
 
-    this._listen('playback:isPlaying', () => {
-      this.setState({ stopped: false, playing: true });
-    });
-
-    this._listen('playback:isPaused', () => {
-      this.setState({ stopped: false, playing: false });
-    });
-
-    this._listen('playback:isStopped', () => {
-      this.setState({ stopped: true, playing: false });
-    });
+    this._listen('playback:isPlaying', () => this.setState({ stopped: false, playing: true }));
+    this._listen('playback:isPaused', () => this.setState({ stopped: false, playing: false }));
+    this._listen('playback:isStopped', () => this.setState({ stopped: true, playing: false }));
 
     this._listen('PlaybackAPI:change:rating', (event, rating) => {
       this.setState({ thumbsUp: rating.liked, thumbsDown: rating.disliked });
     });
 
     this._listen('PlaybackAPI:change:track', (event, track) => {
-      if (track) {
-        this.setState({
-          hasTrack: true,
-          artist: track.artist,
-          album: track.album,
-          track: track.title,
-          albumArt: track.albumArt || ALBUM_ART_PLACEHOLDER,
-        });
-      } else {
-        this.setState({
-          hasTrack: false,
-          artist: undefined,
-          album: undefined,
-          track: undefined,
-          albumArt: ALBUM_ART_PLACEHOLDER,
-        });
-      }
+      this.setState({
+        hasTrack: !!track,
+        artist: (track && track.artist) || undefined,
+        album: (track && track.album) || undefined,
+        track: (track && track.title) || undefined,
+        albumArt: (track && track.albumArt) || ALBUM_ART_PLACEHOLDER,
+      });
     });
 
     // Listen for changes to the window's size so that we can update
@@ -113,30 +119,6 @@ export default class MicroPlayer extends Component {
     this._listeners.push([event, listener]);
   }
 
-  goToPreviousTrack() {
-    Emitter.fireAtGoogle('playback:previousTrack');
-  }
-
-  togglePlay() {
-    Emitter.fireAtGoogle('playback:playPause');
-  }
-
-  goToNextTrack() {
-    Emitter.fireAtGoogle('playback:nextTrack');
-  }
-
-  toggleThumbsUp() {
-    Emitter.fireAtGoogle('playback:toggleThumbsUp');
-  }
-
-  toggleThumbsDown() {
-    Emitter.fireAtGoogle('playback:toggleThumbsDown');
-  }
-
-  showFullWindow() {
-    Emitter.fireAtAll('micro:showMainWindow');
-  }
-
   render() {
     return (
       <div className="micro-player">
@@ -144,24 +126,24 @@ export default class MicroPlayer extends Component {
           <div
             className="album-art"
             style={{ width: this.state.albumArtWidth }}
-            ref={(element) => (this._albumArtElement = element)}
+            ref={element => (this._albumArtElement = element)}
           >
-            <img src={this.state.albumArt} role="presentation" />
+            <img src={this.state.albumArt} alt={`${this.state.artist} - ${this.state.track}`} />
           </div>
 
-          <div className="info-group sm">
-            <span className="artist">{this.state.artist}</span>
-            <span className="separator">&nbsp;-&nbsp;</span>
-            <span className="track">{this.state.track}</span>
-          </div>
+          <JoinedText
+            className="info-group sm"
+            text={[this.state.artist, this.state.track]}
+            textClassNames={['artist', 'track']}
+          />
 
           <div className="info-group lg">
             <div className="track">{this.state.track}</div>
-            <div className="artist-album">
-              <span className="artist">{this.state.artist}</span>
-              <span className="separator">&nbsp;-&nbsp;</span>
-              <span className="album">{this.state.album}</span>
-            </div>
+            <JoinedText
+              className="artist-album"
+              text={[this.state.artist, this.state.album]}
+              textClassNames={['artist', 'album']}
+            />
           </div>
 
           <div className="no-track-message">
@@ -169,81 +151,37 @@ export default class MicroPlayer extends Component {
           </div>
 
           <div className="loader-container">
-            <svg className="circular" viewBox="25 25 50 50">
-              <circle className="path" cx="50" cy="50" r="20" fill="none" strokeWidth="4" strokeMiterlimit="10" />
-            </svg>
+            <LoadingSpinner size="4" />
             <div className="loading-label">
               {TranslationProvider.query('micro-loading')}
             </div>
           </div>
 
-          <div className="micro-drag-handle"></div>
+          <div className="micro-drag-handle" />
         </div>
 
         <div className="controls">
           <div>
-            <button
-              className="like"
-              onClick={this.toggleThumbsUp}
+            <RatingButton
+              type="like"
+              translationKey="playback-label-thumbs-up"
+              checked={this.state.thumbsUp}
               disabled={!this.state.hasTrack}
-              title={TranslationProvider.query('playback-label-thumbs-up')}
-            >
-              {
-                /* eslint-disable max-len */
+              onClick={toggleThumbsUp}
+            />
 
-                // "Outline" icons don't exist in the Material Icons font that's
-                // used in the other buttons, so we need to use SVGs here.
-                this.state.thumbsUp ? (
-                  // https://material.io/resources/icons/?icon=thumb_up&style=baseline
-                  <svg width="24" height="24" viewBox="0 0 24 24">
-                    <path fill="none" d="M0 0h24v24H0V0z" />
-                    <path d="M1 21h4V9H1v12zm22-11c0-1.1-.9-2-2-2h-6.31l.95-4.57.03-.32c0-.41-.17-.79-.44-1.06L14.17 1 7.59 7.59C7.22 7.95 7 8.45 7 9v10c0 1.1.9 2 2 2h9c.83 0 1.54-.5 1.84-1.22l3.02-7.05c.09-.23.14-.47.14-.73v-2z" />
-                  </svg>
-                ) : (
-                  // https://material.io/resources/icons/?icon=thumb_up&style=outline
-                  <svg width="24" height="24" viewBox="0 0 24 24">
-                    <path fill="none" d="M0 0h24v24H0V0zm0 0h24v24H0V0z" />
-                    <path d="M9 21h9c.83 0 1.54-.5 1.84-1.22l3.02-7.05c.09-.23.14-.47.14-.73v-2c0-1.1-.9-2-2-2h-6.31l.95-4.57.03-.32c0-.41-.17-.79-.44-1.06L14.17 1 7.58 7.59C7.22 7.95 7 8.45 7 9v10c0 1.1.9 2 2 2zM9 9l4.34-4.34L12 10h9v2l-3 7H9V9zM1 9h4v12H1z" />
-                  </svg>
-                )
-
-                /* eslint-enable max-len */
-              }
-            </button>
-
-            <button
-              className="dislike"
-              onClick={this.toggleThumbsDown}
+            <RatingButton
+              type="dislike"
+              translationKey="playback-label-thumbs-down"
+              checked={this.state.thumbsDown}
               disabled={!this.state.hasTrack}
-              title={TranslationProvider.query('playback-label-thumbs-down')}
-            >
-              {
-                /* eslint-disable max-len */
-
-                // "Outline" icons don't exist in the Material Icons font that's
-                // used in the other buttons, so we need to use SVGs here.
-                this.state.thumbsDown ? (
-                  // https://material.io/resources/icons/?icon=thumb_down&style=baseline
-                  <svg width="24" height="24" viewBox="0 0 24 24">
-                    <path fill="none" d="M0 0h24v24H0z" />
-                    <path d="M15 3H6c-.83 0-1.54.5-1.84 1.22l-3.02 7.05c-.09.23-.14.47-.14.73v2c0 1.1.9 2 2 2h6.31l-.95 4.57-.03.32c0 .41.17.79.44 1.06L9.83 23l6.59-6.59c.36-.36.58-.86.58-1.41V5c0-1.1-.9-2-2-2zm4 0v12h4V3h-4z" />
-                  </svg>
-                ) : (
-                  // https://material.io/resources/icons/?icon=thumb_down&style=outline
-                  <svg width="24" height="24" viewBox="0 0 24 24">
-                    <path fill="none" d="M0 0h24v24H0V0zm0 0h24v24H0V0z" />
-                    <path d="M15 3H6c-.83 0-1.54.5-1.84 1.22l-3.02 7.05c-.09.23-.14.47-.14.73v2c0 1.1.9 2 2 2h6.31l-.95 4.57-.03.32c0 .41.17.79.44 1.06L9.83 23l6.59-6.59c.36-.36.58-.86.58-1.41V5c0-1.1-.9-2-2-2zm0 12l-4.34 4.34L12 14H3v-2l3-7h9v10zm4-12h4v12h-4z" />
-                  </svg>
-                )
-
-                /* eslint-enable max-len */
-              }
-            </button>
+              onClick={toggleThumbsDown}
+            />
           </div>
 
           <div>
             <button
-              onClick={this.goToPreviousTrack}
+              onClick={goToPreviousTrack}
               className="previous"
               disabled={!this.state.hasTrack}
               title={TranslationProvider.query('playback-label-previous-track')}
@@ -252,7 +190,7 @@ export default class MicroPlayer extends Component {
             </button>
 
             <button
-              onClick={this.togglePlay}
+              onClick={togglePlay}
               className="play-pause"
               disabled={this.state.stopped}
               title={TranslationProvider.query('playback-label-play-pause')}
@@ -261,7 +199,7 @@ export default class MicroPlayer extends Component {
             </button>
 
             <button
-              onClick={this.goToNextTrack}
+              onClick={goToNextTrack}
               className="next"
               disabled={!this.state.hasTrack}
               title={TranslationProvider.query('playback-label-next-track')}
@@ -272,7 +210,7 @@ export default class MicroPlayer extends Component {
 
           <div>
             <button
-              onClick={this.showFullWindow}
+              onClick={showFullWindow}
               className="show-main-window"
               title={TranslationProvider.query('micro-show-main-window')}
             >

--- a/src/renderer/ui/pages/MicroPlayerPage.js
+++ b/src/renderer/ui/pages/MicroPlayerPage.js
@@ -1,0 +1,278 @@
+import React, { Component } from 'react';
+
+const ALBUM_ART_PLACEHOLDER = 'https://www.samuelattard.com/img/gpm_placeholder.jpg';
+
+export default class MicroPlayer extends Component {
+  constructor(...args) {
+    super(...args);
+
+    /** @type [string, Function][] */
+    this._listeners = [];
+
+    this.state = {
+      loading: true,
+      stopped: true,
+      playing: false,
+      thumbsUp: false,
+      thumbsDown: false,
+      hasTrack: false,
+      artist: undefined,
+      album: undefined,
+      track: undefined,
+      albumArt: ALBUM_ART_PLACEHOLDER,
+      albumArtWidth: 0,
+    };
+
+    this._albumArtElement = undefined;
+
+    this._updateAlbumArtWidth = () => {
+      if (this._albumArtElement) {
+        // Make the album art square by setting the
+        // width equal to the element's height.
+        this.setState({ albumArtWidth: this._albumArtElement.clientHeight });
+      }
+    };
+  }
+
+  componentDidMount() {
+    this._listen('app:loaded', () => {
+      this.setState({ loading: false }, () => {
+        // The album art is hidden while loading, so once
+        // the state has been updated, the album art will
+        // be visible, and we'll need to update its width.
+        this._updateAlbumArtWidth();
+      });
+    });
+
+    this._listen('playback:isPlaying', () => {
+      this.setState({ stopped: false, playing: true });
+    });
+
+    this._listen('playback:isPaused', () => {
+      this.setState({ stopped: false, playing: false });
+    });
+
+    this._listen('playback:isStopped', () => {
+      this.setState({ stopped: true, playing: false });
+    });
+
+    this._listen('PlaybackAPI:change:rating', (event, rating) => {
+      this.setState({ thumbsUp: rating.liked, thumbsDown: rating.disliked });
+    });
+
+    this._listen('PlaybackAPI:change:track', (event, track) => {
+      if (track) {
+        this.setState({
+          hasTrack: true,
+          artist: track.artist,
+          album: track.album,
+          track: track.title,
+          albumArt: track.albumArt || ALBUM_ART_PLACEHOLDER,
+        });
+      } else {
+        this.setState({
+          hasTrack: false,
+          artist: undefined,
+          album: undefined,
+          track: undefined,
+          albumArt: ALBUM_ART_PLACEHOLDER,
+        });
+      }
+    });
+
+    // Listen for changes to the window's size so that we can update
+    // the width of the album art to keep that element square. We'll
+    // also need to do an initial update of the album art's width.
+    window.addEventListener('resize', this._updateAlbumArtWidth);
+    this._updateAlbumArtWidth();
+
+    // Emit an event to let the micro player event adapter know
+    // that we are ready. The adapter will then send us the some
+    // events to get our state in sync with the playback state.
+    Emitter.fireAtAll('micro:ready');
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener('resize', this._updateAlbumArtWidth);
+
+    this.listeners.forEach(([event, fn]) => {
+      Emitter.off(event, fn);
+    });
+  }
+
+  _listen(event, listener) {
+    Emitter.on(event, listener);
+    this._listeners.push([event, listener]);
+  }
+
+  goToPreviousTrack() {
+    Emitter.fireAtGoogle('playback:previousTrack');
+  }
+
+  togglePlay() {
+    Emitter.fireAtGoogle('playback:playPause');
+  }
+
+  goToNextTrack() {
+    Emitter.fireAtGoogle('playback:nextTrack');
+  }
+
+  toggleThumbsUp() {
+    Emitter.fireAtGoogle('playback:toggleThumbsUp');
+  }
+
+  toggleThumbsDown() {
+    Emitter.fireAtGoogle('playback:toggleThumbsDown');
+  }
+
+  showFullWindow() {
+    Emitter.fireAtAll('micro:showMainWindow');
+  }
+
+  render() {
+    return (
+      <div className="micro-player">
+        <div className={`info ${(this.state.hasTrack ? '' : 'no-track')} ${this.state.loading ? 'loading' : ''}`}>
+          <div
+            className="album-art"
+            style={{ width: this.state.albumArtWidth }}
+            ref={(element) => (this._albumArtElement = element)}
+          >
+            <img src={this.state.albumArt} role="presentation" />
+          </div>
+
+          <div className="info-group sm">
+            <span className="artist">{this.state.artist}</span>
+            <span className="separator">&nbsp;-&nbsp;</span>
+            <span className="track">{this.state.track}</span>
+          </div>
+
+          <div className="info-group lg">
+            <div className="track">{this.state.track}</div>
+            <div className="artist-album">
+              <span className="artist">{this.state.artist}</span>
+              <span className="separator">&nbsp;-&nbsp;</span>
+              <span className="album">{this.state.album}</span>
+            </div>
+          </div>
+
+          <div className="no-track-message">
+            {TranslationProvider.query('micro-no-track-message')}
+          </div>
+
+          <div className="loader-container">
+            <svg className="circular" viewBox="25 25 50 50">
+              <circle className="path" cx="50" cy="50" r="20" fill="none" strokeWidth="4" strokeMiterlimit="10" />
+            </svg>
+            <div className="loading-label">
+              {TranslationProvider.query('micro-loading')}
+            </div>
+          </div>
+
+          <div className="micro-drag-handle"></div>
+        </div>
+
+        <div className="controls">
+          <div>
+            <button
+              className="like"
+              onClick={this.toggleThumbsUp}
+              disabled={!this.state.hasTrack}
+              title={TranslationProvider.query('playback-label-thumbs-up')}
+            >
+              {
+                /* eslint-disable max-len */
+
+                // "Outline" icons don't exist in the Material Icons font that's
+                // used in the other buttons, so we need to use SVGs here.
+                this.state.thumbsUp ? (
+                  // https://material.io/resources/icons/?icon=thumb_up&style=baseline
+                  <svg width="24" height="24" viewBox="0 0 24 24">
+                    <path fill="none" d="M0 0h24v24H0V0z" />
+                    <path d="M1 21h4V9H1v12zm22-11c0-1.1-.9-2-2-2h-6.31l.95-4.57.03-.32c0-.41-.17-.79-.44-1.06L14.17 1 7.59 7.59C7.22 7.95 7 8.45 7 9v10c0 1.1.9 2 2 2h9c.83 0 1.54-.5 1.84-1.22l3.02-7.05c.09-.23.14-.47.14-.73v-2z" />
+                  </svg>
+                ) : (
+                  // https://material.io/resources/icons/?icon=thumb_up&style=outline
+                  <svg width="24" height="24" viewBox="0 0 24 24">
+                    <path fill="none" d="M0 0h24v24H0V0zm0 0h24v24H0V0z" />
+                    <path d="M9 21h9c.83 0 1.54-.5 1.84-1.22l3.02-7.05c.09-.23.14-.47.14-.73v-2c0-1.1-.9-2-2-2h-6.31l.95-4.57.03-.32c0-.41-.17-.79-.44-1.06L14.17 1 7.58 7.59C7.22 7.95 7 8.45 7 9v10c0 1.1.9 2 2 2zM9 9l4.34-4.34L12 10h9v2l-3 7H9V9zM1 9h4v12H1z" />
+                  </svg>
+                )
+
+                /* eslint-enable max-len */
+              }
+            </button>
+
+            <button
+              className="dislike"
+              onClick={this.toggleThumbsDown}
+              disabled={!this.state.hasTrack}
+              title={TranslationProvider.query('playback-label-thumbs-down')}
+            >
+              {
+                /* eslint-disable max-len */
+
+                // "Outline" icons don't exist in the Material Icons font that's
+                // used in the other buttons, so we need to use SVGs here.
+                this.state.thumbsDown ? (
+                  // https://material.io/resources/icons/?icon=thumb_down&style=baseline
+                  <svg width="24" height="24" viewBox="0 0 24 24">
+                    <path fill="none" d="M0 0h24v24H0z" />
+                    <path d="M15 3H6c-.83 0-1.54.5-1.84 1.22l-3.02 7.05c-.09.23-.14.47-.14.73v2c0 1.1.9 2 2 2h6.31l-.95 4.57-.03.32c0 .41.17.79.44 1.06L9.83 23l6.59-6.59c.36-.36.58-.86.58-1.41V5c0-1.1-.9-2-2-2zm4 0v12h4V3h-4z" />
+                  </svg>
+                ) : (
+                  // https://material.io/resources/icons/?icon=thumb_down&style=outline
+                  <svg width="24" height="24" viewBox="0 0 24 24">
+                    <path fill="none" d="M0 0h24v24H0V0zm0 0h24v24H0V0z" />
+                    <path d="M15 3H6c-.83 0-1.54.5-1.84 1.22l-3.02 7.05c-.09.23-.14.47-.14.73v2c0 1.1.9 2 2 2h6.31l-.95 4.57-.03.32c0 .41.17.79.44 1.06L9.83 23l6.59-6.59c.36-.36.58-.86.58-1.41V5c0-1.1-.9-2-2-2zm0 12l-4.34 4.34L12 14H3v-2l3-7h9v10zm4-12h4v12h-4z" />
+                  </svg>
+                )
+
+                /* eslint-enable max-len */
+              }
+            </button>
+          </div>
+
+          <div>
+            <button
+              onClick={this.goToPreviousTrack}
+              className="previous"
+              disabled={!this.state.hasTrack}
+              title={TranslationProvider.query('playback-label-previous-track')}
+            >
+              <i className="material-icons">skip_previous</i>
+            </button>
+
+            <button
+              onClick={this.togglePlay}
+              className="play-pause"
+              disabled={this.state.stopped}
+              title={TranslationProvider.query('playback-label-play-pause')}
+            >
+              <i className="material-icons">{this.state.playing ? 'pause_circle_filled' : 'play_circle_filled'}</i>
+            </button>
+
+            <button
+              onClick={this.goToNextTrack}
+              className="next"
+              disabled={!this.state.hasTrack}
+              title={TranslationProvider.query('playback-label-next-track')}
+            >
+              <i className="material-icons">skip_next</i>
+            </button>
+          </div>
+
+          <div>
+            <button
+              onClick={this.showFullWindow}
+              className="show-main-window"
+              title={TranslationProvider.query('micro-show-main-window')}
+            >
+              <i className="material-icons">open_in_new</i>
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}

--- a/src/renderer/ui/pages/MicroPlayerPage.js
+++ b/src/renderer/ui/pages/MicroPlayerPage.js
@@ -5,8 +5,6 @@ import JoinedText from '../components/generic/JoinedText';
 import RatingButton from '../components/generic/RatingButton';
 import generateTheme from '../utils/theme';
 
-const ALBUM_ART_PLACEHOLDER = 'https://www.samuelattard.com/img/gpm_placeholder.jpg';
-
 const INITIAL_STATE = {
   loading: true,
   stopped: true,
@@ -17,7 +15,7 @@ const INITIAL_STATE = {
   artist: undefined,
   album: undefined,
   track: undefined,
-  albumArt: ALBUM_ART_PLACEHOLDER,
+  albumArt: null,
   albumArtWidth: 0,
   borderColor: null,
   themeName: '',
@@ -49,20 +47,18 @@ function showFullWindow() {
 }
 
 function getAlbumArtUrl(track) {
-  let url;
-
   if (track && track.albumArt) {
     // YouTube Music will initially use its own URL as the album art,
     // and since that's not an image URL, a "broken" image is shown
     // (https://github.com/gmusic-utils/ytmusic.js/issues/13).
-    // Work around this by ignoring the album art if it starts with the
-    // YouTube Music URL so that we use the placeholder image instead.
+    // Work around this by ignoring the album art if it starts with
+    // the YouTube Music URL so that we use the placeholder instead.
     if (!track.albumArt.startsWith('https://music.youtube.com/')) {
-      url = track.albumArt;
+      return track.albumArt;
     }
   }
 
-  return url || ALBUM_ART_PLACEHOLDER;
+  return null;
 }
 
 export default class MicroPlayer extends Component {
@@ -177,6 +173,7 @@ export default class MicroPlayer extends Component {
 
   render() {
     let styles;
+    let albumArt;
 
     // The play/pause button should use the color from the theme, but we
     // can't apply the color directly to the button via a `style` attribute,
@@ -196,6 +193,18 @@ export default class MicroPlayer extends Component {
       );
     }
 
+    if (this.state.albumArt) {
+      albumArt = <img src={this.state.albumArt} alt={`${this.state.artist} - ${this.state.track}`} />;
+    } else {
+      /* eslint-disable max-len */
+      albumArt = (
+        <svg viewBox="0 0 555 556" style={{ fill: this.state.themeColor }}>
+          <path d="M206.686 468.569c-13.275-5.416-17.807-34.515-17.916-115.057-.084-61.762 2.84-87.036 11.53-99.666 4.309-6.262 7.035-7.334 18.655-7.334 12.131 0 18.68 1.78 22.897 6.222 8.427 8.879 8.501 9.896 8.138 111.278l-.304 85-2.279 5.635c-4.686 11.59-10.949 14.902-27.981 14.801-5.907-.035-11.64-.43-12.74-.879zm114-.56c-5.709-2.02-11.022-8.12-13.193-15.148-1.685-5.455-1.807-11.844-1.807-94.85 0-82.106.137-89.44 1.759-94.683 2-6.462 5.165-10.673 10.534-14.01 3.382-2.104 4.864-2.306 16.879-2.306 15.927 0 17.005.553 22.578 11.58 4.369 8.645 5.958 16.755 7.922 40.42 2.563 30.878 1.176 115.935-2.259 138.5-1.46 9.589-5.468 22.01-8.391 26-1.41 1.925-3.792 4.042-5.293 4.705-3.876 1.711-23.708 1.568-28.729-.208zm-147.772-19.247c-.87-.963-2.332-4.74-3.25-8.393-1.562-6.225-1.983-6.848-6.677-9.89-4.669-3.025-13.04-12.907-14.797-17.467-.423-1.1-2.328-5.375-4.233-9.5-1.904-4.125-3.768-9.138-4.141-11.14-.453-2.428-1.333-3.811-2.642-4.153-3.033-.793-3.65-3.896-4.398-22.101l-.694-16.894-4.42-5.744c-14.463-18.795-29.672-45.034-31.007-53.49-.79-5.002.256-7.705 7.246-18.73l5.611-8.852-1.608-12.955c-.885-7.126-1.89-13.41-2.234-13.967-.344-.557-2.835-2.132-5.536-3.501-2.702-1.369-5.67-3.647-6.598-5.062-1.489-2.273-1.535-3.178-.393-7.743 2.106-8.415 8.096-23.495 13.374-33.668 18.037-34.768 46.114-61.55 83.686-79.83 29.194-14.202 51.618-19.135 86.983-19.132 30.478.002 49.932 3.336 74 12.686 26.24 10.192 55.958 30.659 73.15 50.378 16.583 19.021 30.695 44.461 36.87 66.469 2.707 9.647 1.95 11.927-5.121 15.41-2.771 1.365-5.433 2.957-5.915 3.538-.482.58-1.641 6.895-2.576 14.031l-1.699 12.976 6.643 10.987c3.653 6.043 6.644 12.147 6.645 13.564.01 8.039-11.145 28.985-26.948 50.606l-8.905 12.183-.71 16.817c-.753 17.836-1.348 20.978-4.169 22.02-2.21.815-3.23 2.27-3.25 4.637-.02 2.57-7.845 20.324-11.087 25.16-2.89 4.309-11.28 12.548-14.577 14.312-1.363.73-2.615 3.308-3.827 7.886-2.37 8.946-3.635 10.302-9.62 10.302-2.632 0-5.068-.458-5.414-1.017-.345-.559.057-5.171.893-10.25 2.6-15.784 3.968-45.638 3.975-86.733.007-41.033-1.508-65.935-4.96-81.5-2.464-11.115-2.494-10.957 2.16-11.298 8.95-.658 11.224 2.157 14.258 17.653l1.684 8.607 7.117 1.365 7.117 1.365 7.383-7.242c4.06-3.983 9.901-9.433 12.978-12.11l5.595-4.87 1.754-16.987 1.754-16.987-5.189-8.173c-26.324-41.462-59.243-69.13-96.509-81.113-34.274-11.02-75.361-10.694-108.578.864-24.224 8.429-41.015 19.43-62.422 40.898-14.713 14.756-19.71 21.024-31.07 38.976l-5.661 8.948 1.758 16.58 1.758 16.582 12.887 12.337c10.5 8.979 7.524 13.368 20.1 10.95l7.214-1.387 2.045-9.98c2.349-11.459 3.6-14.197 7.095-15.526 3.265-1.241 10.088-1.225 10.86.026.333.537-.084 3.299-.927 6.137-4.242 14.282-7.112 60.818-6.173 100.076.857 35.82 2.338 61.36 4.208 72.542.85 5.079 1.262 9.691.916 10.25-1.095 1.772-10.02 1.216-11.782-.733z" />
+        </svg>
+      );
+      /* eslint-enable max-len */
+    }
+
     return (
       <div className={`micro-player ${this.state.themeName}`} style={{ borderColor: this.state.borderColor }}>
         {styles}
@@ -205,7 +214,7 @@ export default class MicroPlayer extends Component {
             style={{ width: this.state.albumArtWidth }}
             ref={element => (this._albumArtElement = element)}
           >
-            <img src={this.state.albumArt} alt={`${this.state.artist} - ${this.state.track}`} />
+            {albumArt}
           </div>
 
           <JoinedText

--- a/src/renderer/ui/pages/PlayerPage.js
+++ b/src/renderer/ui/pages/PlayerPage.js
@@ -48,6 +48,11 @@ export default class PlayerPage extends Component {
 
   componentDidMount() {
     Emitter.on('window:updateTitle', this._updateTitle);
+
+    // Emit the "app:loading" event so that other things know the player is
+    // loading. This will occur at startup and also when switching between
+    // GPM and YTM modes, because the main window is reloaded at that point.
+    Emitter.fireAtAll('app:loading');
   }
 
   componentWillUnmount() {

--- a/src/renderer/ui/pages/PlayerPage.js
+++ b/src/renderer/ui/pages/PlayerPage.js
@@ -2,6 +2,7 @@ import { remote, shell } from 'electron';
 import React, { Component } from 'react';
 import { parse as parseURL } from 'url';
 
+import LoadingSpinner from '../components/generic/LoadingSpinner';
 import LyricsViewer from '../components/generic/LyricsViewer';
 import OfflineWarning from '../components/generic/OfflineWarning';
 import WebView from '../components/generic/WebView';
@@ -135,9 +136,7 @@ export default class PlayerPage extends Component {
       <WindowContainer isMainWindow title={process.platform === 'darwin' ? this.state.title : ''} confirmClose={this._confirmCloseWindow}>
         <div className="drag-handle-large"></div>
         <div className={`loader ${this.state.loading ? '' : 'hidden'}`}>
-          <svg className="circular" viewBox="25 25 50 50">
-            <circle className="path" cx="50" cy="50" r="20" fill="none" strokeWidth="2" strokeMiterlimit="10" />
-          </svg>
+          <LoadingSpinner />
         </div>
         <WebView
           ref="view"

--- a/src/renderer/ui/pages/PlayerPage.js
+++ b/src/renderer/ui/pages/PlayerPage.js
@@ -64,6 +64,7 @@ export default class PlayerPage extends Component {
       this.refs.view.executeJavaScript(`window.location = "${this.targetPage}"`);
       setTimeout(() => {
         document.body.removeAttribute('loading');
+        Emitter.fireAtAll('app:loaded');
       }, 900);
       setTimeout(() => {
         this.setState({

--- a/src/renderer/ui/pages/SettingsPage.js
+++ b/src/renderer/ui/pages/SettingsPage.js
@@ -6,6 +6,7 @@ import HotkeyTab from '../components/settings/tabs/HotkeyTab';
 import LastFMTab from '../components/settings/tabs/LastFMTab';
 import ListenBrainzTab from '../components/settings/tabs/ListenBrainzTab';
 import MiniTab from '../components/settings/tabs/MiniTab';
+import MicroTab from '../components/settings/tabs/MicroTab';
 import PlaybackTab from '../components/settings/tabs/PlaybackTab';
 import StyleTab from '../components/settings/tabs/StyleTab';
 import SlackTab from '../components/settings/tabs/SlackTab';
@@ -34,6 +35,9 @@ export default class SettingsPage extends Component {
           </Tab>
           <Tab label={TranslationProvider.query('title-settings-mini')}>
             <MiniTab />
+          </Tab>
+          <Tab label={TranslationProvider.query('title-settings-micro')}>
+            <MicroTab />
           </Tab>
           <Tab label={TranslationProvider.query('title-settings-lastfm')}>
             <LastFMTab />

--- a/src/renderer/windows/GPMWebView/interface/gpm/customUI.js
+++ b/src/renderer/windows/GPMWebView/interface/gpm/customUI.js
@@ -67,19 +67,42 @@ function hideNotWorkingStuff() {
   cssRule('.song-menu.goog-menu.now-playing-menu > .goog-menuitem:nth-child(3) { display: none !important; }');
 }
 
-function installSidebarButton(translationKey, type, icon, index, href, fn) {
-  const elem = document.createElement('a');
+function installSidebarItem(elem, type, index, href, fn) {
   elem.setAttribute('data-type', type);
   elem.setAttribute('class', 'nav-item-container tooltip');
   elem.setAttribute('href', href);
   elem.setAttribute('no-focus', '');
-  elem.innerHTML = `<iron-icon icon="${icon}" alt="" class="x-scope iron-icon-1"></iron-icon><span is="translation-key">${translationKey}</span>`; // eslint-disable-line
   elem.addEventListener('click', fn);
   if (index === -1) {
     document.querySelectorAll('.nav-section.material')[0].appendChild(elem);
   } else {
     document.querySelectorAll('.nav-section.material')[0].insertBefore(elem, document.querySelectorAll('.nav-section.material > a')[index]); // eslint-disable-line
   }
+}
+
+function installSidebarButton(translationKey, type, icon, index, href, fn) {
+  const elem = document.createElement('a');
+  elem.innerHTML = `<iron-icon icon="${icon}" alt="" class="x-scope iron-icon-1"></iron-icon><span is="translation-key">${translationKey}</span>`;
+  installSidebarItem(elem, type, index, href, fn);
+}
+
+function installSidebarToggle(onTranslationKey, offTranslationKey, type, icon, index, href, fn) {
+  const elem = document.createElement('a');
+  elem.innerHTML = `
+    <iron-icon icon="${icon}" alt="" class="x-scope iron-icon-1"></iron-icon>
+    <span is="translation-key">${onTranslationKey}</span>
+    <span is="translation-key">${offTranslationKey}</span>`;
+
+  const update = (value) => {
+    const [on, off] = Array.from(elem.querySelectorAll('span'));
+    on.style.display = value ? '' : 'none';
+    off.style.display = value ? 'none' : '';
+  };
+
+  installSidebarItem(elem, type, index, href, fn);
+  update(false);
+
+  return update;
 }
 
 function installYTMButton() {
@@ -128,10 +151,27 @@ function installAlarmButton() {
   });
 }
 
+/** Create the Micro Player button in the left sidebar */
+function installMicroPlayerButton() {
+  const setter = installSidebarToggle('label-micro-player-on', 'label-micro-player-off', 'microplayer', 'picture-in-picture', 1, '#', (e) => {
+    Emitter.fire('window:microplayer');
+    e.preventDefault();
+    e.stopPropagation();
+    return false;
+  });
+
+  setter(Settings.get('microplayer-enabled'));
+
+  Emitter.on('settings:change:microplayer-enabled', (event, visible) => {
+    setter(visible);
+  });
+}
+
 function installMainMenu() {
   installDesktopSettingsButton();
   installQuitButton();
   installAlarmButton();
+  installMicroPlayerButton();
 }
 
 /* eslint-disable max-len, no-multi-str */

--- a/src/renderer/windows/GPMWebView/interface/gpm/customUI.js
+++ b/src/renderer/windows/GPMWebView/interface/gpm/customUI.js
@@ -67,31 +67,36 @@ function hideNotWorkingStuff() {
   cssRule('.song-menu.goog-menu.now-playing-menu > .goog-menuitem:nth-child(3) { display: none !important; }');
 }
 
-function installSidebarItem(elem, type, index, href, fn) {
-  elem.setAttribute('data-type', type);
+function installSidebarItem(elem, settings, fn) {
+  elem.setAttribute('data-type', settings.type);
   elem.setAttribute('class', 'nav-item-container tooltip');
-  elem.setAttribute('href', href);
+  elem.setAttribute('href', settings.href || '#');
   elem.setAttribute('no-focus', '');
   elem.addEventListener('click', fn);
-  if (index === -1) {
+  if (settings.index === -1) {
     document.querySelectorAll('.nav-section.material')[0].appendChild(elem);
   } else {
-    document.querySelectorAll('.nav-section.material')[0].insertBefore(elem, document.querySelectorAll('.nav-section.material > a')[index]); // eslint-disable-line
+    document.querySelectorAll('.nav-section.material')[0].insertBefore(
+      elem,
+      document.querySelectorAll('.nav-section.material > a')[settings.index],
+    );
   }
 }
 
-function installSidebarButton(translationKey, type, icon, index, href, fn) {
-  const elem = document.createElement('a');
-  elem.innerHTML = `<iron-icon icon="${icon}" alt="" class="x-scope iron-icon-1"></iron-icon><span is="translation-key">${translationKey}</span>`;
-  installSidebarItem(elem, type, index, href, fn);
-}
-
-function installSidebarToggle(onTranslationKey, offTranslationKey, type, icon, index, href, fn) {
+function installSidebarButton(settings, fn) {
   const elem = document.createElement('a');
   elem.innerHTML = `
-    <iron-icon icon="${icon}" alt="" class="x-scope iron-icon-1"></iron-icon>
-    <span is="translation-key">${onTranslationKey}</span>
-    <span is="translation-key">${offTranslationKey}</span>`;
+    <iron-icon icon="${settings.icon}" alt="" class="x-scope iron-icon-1"></iron-icon>
+    <span is="translation-key">${settings.translationKey}</span>`;
+  installSidebarItem(elem, settings, fn);
+}
+
+function installSidebarToggle(settings, fn) {
+  const elem = document.createElement('a');
+  elem.innerHTML = `
+    <iron-icon icon="${settings.icon}" alt="" class="x-scope iron-icon-1"></iron-icon>
+    <span is="translation-key">${settings.onTranslationKey}</span>
+    <span is="translation-key">${settings.offTranslationKey}</span>`;
 
   const update = (value) => {
     const [on, off] = Array.from(elem.querySelectorAll('span'));
@@ -99,7 +104,7 @@ function installSidebarToggle(onTranslationKey, offTranslationKey, type, icon, i
     off.style.display = value ? 'none' : '';
   };
 
-  installSidebarItem(elem, type, index, href, fn);
+  installSidebarItem(elem, settings, fn);
   update(false);
 
   return update;
@@ -122,7 +127,12 @@ function installYTMButton() {
 
 /** Create the Desktop Settings button in the left sidebar */
 function installDesktopSettingsButton() {
-  installSidebarButton('label-desktop-settings', 'desktopsettings', 'settings', 2, '#', (e) => {
+  installSidebarButton({
+    translationKey: 'label-desktop-settings',
+    type: 'desktopsettings',
+    icon: 'settings',
+    index: 2,
+  }, (e) => {
     Emitter.fire('window:settings');
     e.preventDefault();
     e.stopPropagation();
@@ -132,7 +142,12 @@ function installDesktopSettingsButton() {
 
 /** Create the Quit button in the left sidebar */
 function installQuitButton() {
-  installSidebarButton('label-quit', 'quit', 'exit-to-app', -1, '#', (e) => {
+  installSidebarButton({
+    translationKey: 'label-quit',
+    type: 'quit',
+    icon: 'exit-to-app',
+    index: -1,
+  }, (e) => {
     remote.app.quit();
     e.preventDefault();
     e.stopPropagation();
@@ -141,7 +156,12 @@ function installQuitButton() {
 }
 
 function installAlarmButton() {
-  installSidebarButton('label-alarm', 'alarm', 'alarm', 0, '#', (e) => {
+  installSidebarButton({
+    translationKey: 'label-alarm',
+    type: 'alarm',
+    icon: 'alarm',
+    index: 0,
+  }, (e) => {
     // Closes the sliding drawer
     document.querySelector('paper-drawer-panel').setAttribute('selected', 'main');
     Emitter.fireAtMain('alarm:show');
@@ -153,7 +173,13 @@ function installAlarmButton() {
 
 /** Create the Micro Player button in the left sidebar */
 function installMicroPlayerButton() {
-  const setter = installSidebarToggle('label-micro-player-on', 'label-micro-player-off', 'microplayer', 'picture-in-picture', 1, '#', (e) => {
+  const setter = installSidebarToggle({
+    onTranslationKey: 'label-micro-player-on',
+    offTranslationKey: 'label-micro-player-off',
+    type: 'microplayer',
+    icon: 'picture-in-picture',
+    index: 1,
+  }, (e) => {
     Emitter.fire('window:microplayer');
     e.preventDefault();
     e.stopPropagation();

--- a/src/renderer/windows/GPMWebView/interface/ytm/customUI.js
+++ b/src/renderer/windows/GPMWebView/interface/ytm/customUI.js
@@ -1,22 +1,44 @@
 import { remote } from 'electron';
 
-function installGPMButton() {
+function addButton(id, click) {
   const elem = document.createElement('paper-button');
-  elem.setAttribute('id', 'gpm-button');
+  elem.setAttribute('id', id);
   elem.setAttribute('class', 'yt-button-renderer');
   elem.setAttribute('style', 'background: #212121; color: orange; font-weight: bold;');
-  elem.innerHTML = '<span is="translation-key">button-text-gpm-switch</span>';
-  elem.addEventListener('click', () => {
+  elem.addEventListener('click', click);
+
+  document.querySelector('#right-content').prepend(elem);
+
+  return elem;
+}
+
+function installGPMButton() {
+  const elem = addButton('gpm-button', () => {
     const mainWindow = remote.getCurrentWindow();
     Settings.set('service', 'google-play-music');
     mainWindow.hide();
     mainWindow.reload();
   });
-  document.querySelector('#right-content').prepend(elem);
+
+  elem.innerHTML = '<span is="translation-key">button-text-gpm-switch</span>';
+}
+
+function installMicroPlayerButton() {
+  const elem = addButton('micro-player-button', () => {
+    Emitter.fire('window:microplayer');
+  });
+
+  const setter = (checked) => {
+    elem.innerHTML = `<span is="translation-key">label-micro-player-${checked ? 'on' : 'off'}</span>`;
+  };
+
+  setter(Settings.get('microplayer-enabled'));
+  Emitter.on('settings:change:microplayer-enabled', (event, visible) => setter(visible));
 }
 
 
 // Modify the GUI after everything is sufficiently loaded
 window.wait(() => {
   installGPMButton();
+  installMicroPlayerButton();
 });

--- a/src/renderer/windows/micro_player.js
+++ b/src/renderer/windows/micro_player.js
@@ -1,0 +1,11 @@
+import { remote } from 'electron';
+import React from 'react';
+import ReactDOM from 'react-dom';
+import injectTapEventPlugin from 'react-tap-event-plugin';
+
+import MicroPlayerPage from '../ui/pages/MicroPlayerPage';
+
+injectTapEventPlugin();
+
+ReactDOM.render(<MicroPlayerPage />, document.body);
+remote.getCurrentWindow().show();

--- a/src/renderer/windows/micro_player.js
+++ b/src/renderer/windows/micro_player.js
@@ -7,5 +7,5 @@ import MicroPlayerPage from '../ui/pages/MicroPlayerPage';
 
 injectTapEventPlugin();
 
-ReactDOM.render(<MicroPlayerPage />, document.body);
+ReactDOM.render(<MicroPlayerPage />, document.querySelector('#micro-player'));
 remote.getCurrentWindow().show();

--- a/test/electron-renderer/ui/JoinedText_spec.js
+++ b/test/electron-renderer/ui/JoinedText_spec.js
@@ -1,0 +1,70 @@
+/* eslint-disable no-unused-expressions */
+
+import React from 'react';
+import { expect } from 'chai';
+import { mount } from 'enzyme';
+
+import JoinedText from '../../../build/renderer/ui/components/generic/JoinedText';
+
+describe('<JoinedText />', () => {
+  function getSpans(component) {
+    return component.find('div > span');
+  }
+  it('should render the text separated by the separator text', () => {
+    const component = mount(
+      <JoinedText
+        text={['foo', 'bar', 'meep']}
+        separator=":"
+      />
+    );
+    expect(getSpans(component).map(x => x.text())).to.deep.equal([
+      'foo',
+      ':',
+      'bar',
+      ':',
+      'meep',
+    ]);
+  });
+
+  it('should use &nbsp; as the default separator', () => {
+    const component = mount(
+      <JoinedText
+        text={['foo', 'bar', 'meep']}
+      />
+    );
+    expect(getSpans(component).map(x => x.text())).to.deep.equal([
+      'foo',
+      '\u00a0-\u00a0',
+      'bar',
+      '\u00a0-\u00a0',
+      'meep',
+    ]);
+  });
+
+  it('should apply the given class name to the root element', () => {
+    const component = mount(
+      <JoinedText
+        text={['foo', 'bar', 'meep']}
+        className="test"
+      />
+    );
+    const div = component.find('div');
+    expect(div.props().className).to.equal('test');
+  });
+
+  it('should apply the given class names to the text elements', () => {
+    const component = mount(
+      <JoinedText
+        text={['foo', 'bar', 'meep']}
+        textClassNames={['alpha', 'beta', 'gamma']}
+      />
+    );
+    expect(getSpans(component).map(x => x.props().className)).to.deep.equal([
+      'alpha',
+      'separator',
+      'beta',
+      'separator',
+      'gamma',
+    ]);
+  });
+});

--- a/test/electron-renderer/ui/RatingButton_spec.js
+++ b/test/electron-renderer/ui/RatingButton_spec.js
@@ -1,0 +1,116 @@
+/* eslint-disable no-unused-expressions */
+
+import React from 'react';
+import chai, { expect } from 'chai';
+import { mount } from 'enzyme';
+
+import RatingButton from '../../../build/renderer/ui/components/generic/RatingButton';
+import mockSettings from './_mockSettings';
+
+chai.should();
+
+describe('<RatingButton />', () => {
+  beforeEach(() => {
+    mockSettings();
+  });
+
+  it('should render a button', () => {
+    const component = mount(
+      <RatingButton
+        type="like"
+        translationKey="foo"
+        checked
+      />
+    );
+    component.find('button').length.should.be.equal(1);
+  });
+
+  [
+    ['like', true, 'like-checked'],
+    ['like', false, 'like-unchecked'],
+    ['dislike', true, 'dislike-checked'],
+    ['dislike', false, 'dislike-unchecked'],
+  ].forEach(([type, checked, className]) => {
+    it(`should render the correct icon when type is "${type}" and checked is ${checked}`, () => {
+      const component = mount(
+        <RatingButton
+          type={type}
+          translationKey="foo"
+          checked={checked}
+        />
+      );
+      component.find(`svg.${className}`).length.should.be.equal(1);
+    });
+  });
+
+  [
+    ['like', 'like-checked', 'like-unchecked'],
+    ['dislike', 'dislike-checked', 'dislike-unchecked'],
+  ].forEach(([type, checkedClassName, uncheckedClassName]) => {
+    it(`should update the icon when type is "${type}" and checked changes`, () => {
+      const component = mount(
+        <RatingButton
+          type={type}
+          translationKey="foo"
+          checked
+        />
+      );
+      const button = component.find('svg');
+      expect(button).to.exist;
+
+      expect(button.props().className).to.equal(checkedClassName);
+
+      component.setProps({ checked: false });
+
+      expect(button.props().className).to.equal(uncheckedClassName);
+    });
+  });
+
+  it('should disable the button when disabled', () => {
+    const component = mount(
+      <RatingButton
+        type="like"
+        translationKey="foo"
+        checked
+        disabled
+      />
+    );
+    const button = component.find('button');
+    expect(button).to.exist;
+    expect(button.props().disabled).to.be.true;
+
+    component.setProps({ disabled: false });
+
+    expect(button.props().disabled).to.be.false;
+  });
+
+  ['like', 'dislike'].forEach(type => {
+    it(`should set the class name to "${type}" when type is "${type}".`, () => {
+      const component = mount(
+        <RatingButton
+          type={type}
+          translationKey="foo"
+          checked
+        />
+      );
+      const button = component.find('button');
+      expect(button).to.exist;
+      expect(button.props().className).to.equal(type);
+    });
+  });
+
+  it('should call the click handler when the button is clicked', () => {
+    let called = false;
+    const component = mount(
+      <RatingButton
+        type="like"
+        translationKey="foo"
+        checked
+        onClick={() => (called = true)}
+      />
+    );
+    expect(called).to.be.false;
+    component.find('button').simulate('click');
+    expect(called).to.be.true;
+  });
+});

--- a/test/electron-renderer/ui/_mockSettings.js
+++ b/test/electron-renderer/ui/_mockSettings.js
@@ -51,6 +51,9 @@ export default () => {
     fireAtGoogle: (what, ...args) => {
       global.Emitter.fire(what, ...args);
     },
+    fireAtAll: (what, ...args) => {
+      global.Emitter.fire(what, ...args);
+    },
     on: (what, fn) => {
       hooks[what] = hooks[what] || [];
       hooks[what].push(fn);

--- a/test/electron-renderer/ui/pages/MicroPlayerPage_spec.js
+++ b/test/electron-renderer/ui/pages/MicroPlayerPage_spec.js
@@ -1,0 +1,286 @@
+/* eslint-disable no-unused-expressions */
+import React from 'react';
+import chai, { expect } from 'chai';
+import sinon from 'sinon';
+import { mount } from 'enzyme';
+
+import MicroPlayerPage from '../../../../build/renderer/ui/pages/MicroPlayerPage';
+import mockSettings, { getVars, mockEvent } from '../_mockSettings';
+
+chai.should();
+
+describe('<MicroPlayerPage />', () => {
+  let component;
+  let fired;
+
+  function track(details) {
+    return Object.assign({
+      artist: 'alpha',
+      album: 'beta',
+      title: 'gamma',
+      albumArt: 'delta',
+    }, details || {});
+  }
+
+  beforeEach(() => {
+    mockSettings();
+    fired = getVars().fired;
+
+    component = mount(<MicroPlayerPage />);
+  });
+
+  describe('loading', () => {
+    it('should not be loading after receiving the "app:loaded" message.', () => {
+      expect(component.state().loading).to.be.true;
+      mockEvent('app:loaded');
+      expect(component.state().loading).to.be.false;
+    });
+
+    it('should emit "micro:ready" event after mounting.', () => {
+      expect(fired['micro:ready']).to.have.lengthOf(1);
+    });
+  });
+
+  describe('controls', () => {
+    function find(className) {
+      return component.find(`.micro-player .controls .${className}`);
+    }
+
+    function verifyDisabled(...classNames) {
+      classNames.forEach((name) => {
+        const element = find(name);
+        expect(element.props().disabled, name).to.be.true;
+      });
+    }
+
+    function verifyEnabled(...classNames) {
+      classNames.forEach((name) => {
+        const element = find(name);
+        expect(element.props().disabled, name).to.be.falsy;
+      });
+    }
+
+    it('should initially disable the like/dislike buttons.', () => {
+      verifyDisabled('like', 'dislike');
+    });
+
+    it('should initially disable the previous/play/next buttons.', () => {
+      verifyDisabled('previous', 'play-pause', 'next');
+    });
+
+    it('should initially enable the "open main window" button.', () => {
+      verifyEnabled('show-main-window');
+    });
+
+    it('should enable the like/dislike buttons when there is a track.', () => {
+      mockEvent('PlaybackAPI:change:track', track());
+      verifyEnabled('like', 'dislike');
+
+      mockEvent('PlaybackAPI:change:track', undefined);
+      verifyDisabled('like', 'dislike');
+    });
+
+    it('should enable the previous/next buttons when there is a track.', () => {
+      mockEvent('PlaybackAPI:change:track', track());
+      verifyEnabled('previous', 'next');
+
+      mockEvent('PlaybackAPI:change:track', undefined);
+      verifyDisabled('previous', 'next');
+    });
+
+    it('should not enable the play button when there is a track but player is stopped.', () => {
+      mockEvent('PlaybackAPI:change:track', track());
+      verifyDisabled('play-pause');
+    });
+
+    it('should enable the play button when there the player is playing.', () => {
+      verifyDisabled('play-pause');
+      mockEvent('playback:isPlaying');
+      verifyEnabled('play-pause');
+    });
+
+    it('should enable the play button when there the player is paused.', () => {
+      verifyDisabled('play-pause');
+      mockEvent('playback:isPaused');
+      verifyEnabled('play-pause');
+    });
+
+    it('should disable the play button when there the player is stopped.', () => {
+      verifyDisabled('play-pause');
+      mockEvent('playback:isPaused');
+      verifyEnabled('play-pause');
+      mockEvent('playback:isStopped');
+      verifyDisabled('play-pause');
+    });
+
+    it('should be flagged as playing when player is playing.', () => {
+      expect(component.state().playing, 'initial').to.be.false;
+
+      mockEvent('playback:isPlaying');
+      expect(component.state().playing, 'playing').to.be.true;
+
+      mockEvent('playback:isPaused');
+      expect(component.state().playing, 'paused').to.be.false;
+
+      mockEvent('playback:isPlaying');
+      expect(component.state().playing, 'playing again').to.be.true;
+
+      mockEvent('playback:isStopped');
+      expect(component.state().playing, 'stopped').to.be.false;
+    });
+
+    it('should be flagged as stopped when player is stopped.', () => {
+      expect(component.state().stopped, 'initial').to.be.true;
+
+      mockEvent('playback:isPlaying');
+      expect(component.state().stopped, 'playing').to.be.false;
+
+      mockEvent('playback:isStopped');
+      expect(component.state().stopped, 'stopped').to.be.true;
+
+      mockEvent('playback:isPaused');
+      expect(component.state().stopped, 'paused').to.be.false;
+    });
+
+    it('should be flagged as liked when the rating is liked.', () => {
+      expect(component.state().thumbsUp, 'initial').to.be.false;
+
+      mockEvent('PlaybackAPI:change:rating', { liked: true, disliked: false });
+      expect(component.state().thumbsUp, 'liked').to.be.true;
+
+      mockEvent('PlaybackAPI:change:rating', { liked: false, disliked: true });
+      expect(component.state().thumbsUp, 'disliked').to.be.false;
+    });
+
+    it('should be flagged as disliked when the rating is disliked.', () => {
+      expect(component.state().thumbsDown, 'initial').to.be.false;
+
+      mockEvent('PlaybackAPI:change:rating', { liked: false, disliked: true });
+      expect(component.state().thumbsDown, 'disliked').to.be.true;
+
+      mockEvent('PlaybackAPI:change:rating', { liked: true, disliked: false });
+      expect(component.state().thumbsDown, 'liked').to.be.false;
+    });
+
+    it('should go to the previous track when the "previous" button is clicked.', () => {
+      mockEvent('PlaybackAPI:change:track', track());
+
+      component.find('.controls .previous').simulate('click');
+      expect(fired).to.haveOwnProperty('playback:previousTrack');
+    });
+
+    it('should toggle playing when the "play" button is clicked.', () => {
+      mockEvent('PlaybackAPI:change:track', track());
+      mockEvent('playback:isPlaying');
+
+      component.find('.controls .play-pause').simulate('click');
+      expect(fired).to.haveOwnProperty('playback:playPause');
+    });
+
+    it('should go to the next track when the "next" button is clicked.', () => {
+      mockEvent('PlaybackAPI:change:track', track());
+
+      component.find('.controls .next').simulate('click');
+      expect(fired).to.haveOwnProperty('playback:nextTrack');
+    });
+
+    it('should toggle thumbs up when the like button is clicked.', () => {
+      mockEvent('PlaybackAPI:change:track', track());
+
+      component.find('.controls .like').simulate('click');
+      expect(fired).to.haveOwnProperty('playback:toggleThumbsUp');
+    });
+
+    it('should toggle thumbs down when the dislike button is clicked.', () => {
+      mockEvent('PlaybackAPI:change:track', track());
+
+      component.find('.controls .dislike').simulate('click');
+      expect(fired).to.haveOwnProperty('playback:toggleThumbsDown');
+    });
+  });
+
+  describe('track', () => {
+    it('should initially not have a track.', () => {
+      expect(component.state().hasTrack).to.be.false;
+    });
+
+    it('should show the artist and track name in the small view.', () => {
+      mockEvent('PlaybackAPI:change:track', track({ artist: 'one', album: 'two', title: 'three' }));
+      expect(component.find('.info-group.sm').text()).to.equal('one\u00a0-\u00a0three');
+    });
+
+    it('should show the artist, album and track name in the small view.', () => {
+      mockEvent('PlaybackAPI:change:track', track({ artist: 'one', album: 'two', title: 'three' }));
+      expect(component.find('.info-group.lg .track').text()).to.equal('three');
+      expect(component.find('.info-group.lg .artist-album').text()).to.equal('one\u00a0-\u00a0two');
+    });
+
+    it('should show the album art when there is a track with album art.', () => {
+      mockEvent('PlaybackAPI:change:track', track({ albumArt: 'image' }));
+      expect(component.find('.info .album-art img').props().src).to.equal('image');
+    });
+
+    it('should show a placeholder for the album art when there is a track without album art.', () => {
+      mockEvent('PlaybackAPI:change:track', track({ albumArt: 'image' }));
+      expect(component.find('.info .album-art img').props().src).to.equal('image');
+
+      mockEvent('PlaybackAPI:change:track', track({ albumArt: undefined }));
+      expect(component.find('.info .album-art img').props().src).to.equal('https://www.samuelattard.com/img/gpm_placeholder.jpg');
+    });
+
+    it('should show a placeholder for the album art when there is no track.', () => {
+      mockEvent('PlaybackAPI:change:track', track({ albumArt: 'image' }));
+      expect(component.find('.info .album-art img').props().src).to.equal('image');
+
+      mockEvent('PlaybackAPI:change:track', undefined);
+      expect(component.find('.info .album-art img').props().src).to.equal('https://www.samuelattard.com/img/gpm_placeholder.jpg');
+    });
+  });
+
+  describe('show main window', () => {
+    it('should always enable the "show main window" button.', () => {
+      const button = component.find('.show-main-window');
+      expect(button.props().disabled, 'initial').to.be.falsy;
+
+      mockEvent('playback:isPlaying');
+      expect(button.props().disabled, 'playing').to.be.falsy;
+
+      mockEvent('playback:isStopped');
+      expect(button.props().disabled, 'stopped').to.be.falsy;
+
+      mockEvent('PlaybackAPI:change:track', track());
+      expect(button.props().disabled, 'track').to.be.falsy;
+    });
+
+    it('should emit the "micro:showMainWindow" event when the "show main window" button is clicked.', () => {
+      const button = component.find('.show-main-window');
+      button.simulate('click');
+      expect(fired).to.haveOwnProperty('micro:showMainWindow');
+    });
+  });
+
+  describe('resize', () => {
+    let sandbox;
+
+    beforeEach(() => {
+      sandbox = sinon.sandbox.create();
+    });
+
+    it('should update the album art width when the window is resized.', () => {
+      const container = component.find('.album-art');
+      expect(container.props().style, 'initial').to.deep.equal({ width: 0 });
+
+      // Verify that the album art element exists, but then
+      // replace it so that we can stub the client height.
+      expect(component.instance()._albumArtElement).to.exist;
+      component.instance()._albumArtElement = { clientHeight: 123 };
+
+      window.dispatchEvent(new Event('resize'));
+      expect(container.props().style, 'resized').to.deep.equal({ width: 123 });
+    });
+
+    afterEach(() => {
+      sandbox.restore();
+    });
+  });
+});

--- a/test/electron-renderer/ui/pages/MicroPlayerPage_spec.js
+++ b/test/electron-renderer/ui/pages/MicroPlayerPage_spec.js
@@ -80,7 +80,7 @@ describe('<MicroPlayerPage />', () => {
         artist: undefined,
         album: undefined,
         track: undefined,
-        albumArt: 'https://www.samuelattard.com/img/gpm_placeholder.jpg',
+        albumArt: null,
         playing: false,
         stopped: true,
         thumbsUp: false,
@@ -335,9 +335,11 @@ describe('<MicroPlayerPage />', () => {
     it('should show a placeholder for the album art when there is a track without album art.', () => {
       mockEvent('PlaybackAPI:change:track', track({ albumArt: 'image' }));
       expect(component.find('.info .album-art img').props().src).to.equal('image');
+      expect(component.find('.info .album-art svg').length).to.equal(0);
 
       mockEvent('PlaybackAPI:change:track', track({ albumArt: undefined }));
-      expect(component.find('.info .album-art img').props().src).to.equal('https://www.samuelattard.com/img/gpm_placeholder.jpg');
+      expect(component.find('.info .album-art img').length).to.equal(0);
+      expect(component.find('.info .album-art svg').length).to.equal(1);
     });
 
     it('should show a placeholder for the album art when there is no track.', () => {
@@ -345,7 +347,8 @@ describe('<MicroPlayerPage />', () => {
       expect(component.find('.info .album-art img').props().src).to.equal('image');
 
       mockEvent('PlaybackAPI:change:track', undefined);
-      expect(component.find('.info .album-art img').props().src).to.equal('https://www.samuelattard.com/img/gpm_placeholder.jpg');
+      expect(component.find('.info .album-art img').length).to.equal(0);
+      expect(component.find('.info .album-art svg').length).to.equal(1);
     });
   });
 

--- a/test/electron-renderer/ui/pages/MicroPlayerPage_spec.js
+++ b/test/electron-renderer/ui/pages/MicroPlayerPage_spec.js
@@ -5,7 +5,7 @@ import sinon from 'sinon';
 import { mount } from 'enzyme';
 
 import MicroPlayerPage from '../../../../build/renderer/ui/pages/MicroPlayerPage';
-import mockSettings, { getVars, mockEvent } from '../_mockSettings';
+import mockSettings, { fakeSettings, getVars, mockEvent } from '../_mockSettings';
 
 chai.should();
 
@@ -24,6 +24,9 @@ describe('<MicroPlayerPage />', () => {
 
   beforeEach(() => {
     mockSettings();
+    fakeSettings('theme', false);
+    fakeSettings('themeColor', 'red');
+    fakeSettings('themeType', 'normal');
     fired = getVars().fired;
 
     component = mount(<MicroPlayerPage />);
@@ -64,6 +67,9 @@ describe('<MicroPlayerPage />', () => {
         thumbsUp: false,
         thumbsDown: true,
         albumArtWidth: 0,
+        borderColor: '',
+        themeName: '',
+        themeColor: '',
       });
 
       mockEvent('app:loading');
@@ -80,7 +86,70 @@ describe('<MicroPlayerPage />', () => {
         thumbsUp: false,
         thumbsDown: false,
         albumArtWidth: 0,
+        borderColor: '',
+        themeName: '',
+        themeColor: '',
       });
+    });
+  });
+
+  describe('theme', () => {
+    it('should clear the theme-based state when theming is disabled.', () => {
+      mockEvent('settings:change:theme', true);
+      mockEvent('settings:change:themeColor', '#ff0000');
+      mockEvent('settings:change:themeType', 'HIGHLIGHT_ONLY');
+
+      expect(component.state().borderColor).to.not.equal('');
+      expect(component.state().themeName).to.not.equal('');
+      expect(component.state().themeColor).to.not.equal('');
+
+      mockEvent('settings:change:theme', false);
+
+      expect(component.state()).to.contain({
+        borderColor: '',
+        themeName: '',
+        themeColor: '',
+      });
+    });
+
+    it('should the set theme-based state correctly when the light theme is enabled.', () => {
+      mockEvent('settings:change:theme', true);
+      mockEvent('settings:change:themeColor', '#ff0000');
+      mockEvent('settings:change:themeType', 'HIGHLIGHT_ONLY');
+
+      expect(component.state()).to.contain({
+        borderColor: '#ff0000',
+        themeName: 'light',
+        themeColor: '#ff0000',
+      });
+    });
+
+    it('should the set theme-based state correctly when the dark theme is enabled.', () => {
+      mockEvent('settings:change:theme', true);
+      mockEvent('settings:change:themeColor', '#00ff00');
+      mockEvent('settings:change:themeType', 'FULL');
+
+      expect(component.state()).to.contain({
+        borderColor: '#222326',
+        themeName: 'dark',
+        themeColor: '#00ff00',
+      });
+    });
+
+    it('should use the theme name as a CSS class on the player element.', () => {
+      mockEvent('settings:change:theme', true);
+      mockEvent('settings:change:themeColor', '#00ff00');
+      mockEvent('settings:change:themeType', 'FULL');
+
+      expect(component.find('.micro-player').hasClass('dark')).to.be.true;
+    });
+
+    it('should apply the theme border color to the player element.', () => {
+      mockEvent('settings:change:theme', true);
+      mockEvent('settings:change:themeColor', '#00ff00');
+      mockEvent('settings:change:themeType', 'HIGHLIGHT_ONLY');
+
+      expect(component.find('.micro-player').props().style.borderColor).to.equal('#00ff00');
     });
   });
 

--- a/test/electron-renderer/ui/pages/MicroPlayerPage_spec.js
+++ b/test/electron-renderer/ui/pages/MicroPlayerPage_spec.js
@@ -39,6 +39,49 @@ describe('<MicroPlayerPage />', () => {
     it('should emit "micro:ready" event after mounting.', () => {
       expect(fired['micro:ready']).to.have.lengthOf(1);
     });
+
+    it('should reset state after receiving the "app:loading" message.', () => {
+      // Fire some events to mutate the state.
+      mockEvent('app:loaded');
+      mockEvent('PlaybackAPI:change:track', track({
+        artist: 'a',
+        album: 'b',
+        title: 'c',
+        albumArt: 'd',
+      }));
+      mockEvent('playback:isPlaying');
+      mockEvent('PlaybackAPI:change:rating', { liked: false, disliked: true });
+
+      expect(component.state()).to.deep.equal({
+        loading: false,
+        hasTrack: true,
+        artist: 'a',
+        album: 'b',
+        track: 'c',
+        albumArt: 'd',
+        playing: true,
+        stopped: false,
+        thumbsUp: false,
+        thumbsDown: true,
+        albumArtWidth: 0,
+      });
+
+      mockEvent('app:loading');
+
+      expect(component.state()).to.deep.equal({
+        loading: true,
+        hasTrack: false,
+        artist: undefined,
+        album: undefined,
+        track: undefined,
+        albumArt: 'https://www.samuelattard.com/img/gpm_placeholder.jpg',
+        playing: false,
+        stopped: true,
+        thumbsUp: false,
+        thumbsDown: false,
+        albumArtWidth: 0,
+      });
+    });
   });
 
   describe('controls', () => {

--- a/test/electron-renderer/ui/pages/MicroPlayerPage_spec.js
+++ b/test/electron-renderer/ui/pages/MicroPlayerPage_spec.js
@@ -27,6 +27,11 @@ describe('<MicroPlayerPage />', () => {
     fakeSettings('theme', false);
     fakeSettings('themeColor', 'red');
     fakeSettings('themeType', 'normal');
+    fakeSettings('microButtonsRating', true);
+    fakeSettings('microButtonsPrevious', true);
+    fakeSettings('microButtonsPlayPause', true);
+    fakeSettings('microButtonsNext', true);
+    fakeSettings('microButtonsShowMainWindow', true);
     fired = getVars().fired;
 
     component = mount(<MicroPlayerPage />);
@@ -70,6 +75,15 @@ describe('<MicroPlayerPage />', () => {
         borderColor: '',
         themeName: '',
         themeColor: '',
+        visibility: {
+          rating: true,
+          previous: true,
+          playPause: true,
+          next: true,
+          showMainWindow: true,
+          controls: true,
+          navigation: true,
+        },
       });
 
       mockEvent('app:loading');
@@ -89,6 +103,15 @@ describe('<MicroPlayerPage />', () => {
         borderColor: '',
         themeName: '',
         themeColor: '',
+        visibility: {
+          rating: true,
+          previous: true,
+          playPause: true,
+          next: true,
+          showMainWindow: true,
+          controls: true,
+          navigation: true,
+        },
       });
     });
   });
@@ -396,6 +419,114 @@ describe('<MicroPlayerPage />', () => {
 
     afterEach(() => {
       sandbox.restore();
+    });
+  });
+
+  describe('visibility', () => {
+    function verifyVisibility(selector, setting) {
+      expect(component.find(selector).exists(), 'initial').to.be.true;
+
+      mockEvent(`settings:change:${setting}`, false);
+
+      expect(component.find(selector).exists(), 'hidden').to.be.false;
+
+      mockEvent(`settings:change:${setting}`, true);
+
+      expect(component.find(selector).exists(), 'shown').to.be.true;
+    }
+
+    it('should initialize visibility from the settings.', () => {
+      fakeSettings('microButtonsRating', false);
+      fakeSettings('microButtonsPrevious', true);
+      fakeSettings('microButtonsPlayPause', false);
+      fakeSettings('microButtonsNext', true);
+      fakeSettings('microButtonsShowMainWindow', false);
+
+      mockEvent('app:loading');
+
+      expect(component.state().visibility).to.deep.equal({
+        rating: false,
+        previous: true,
+        playPause: false,
+        next: true,
+        showMainWindow: false,
+        controls: true,
+        navigation: true,
+      });
+    });
+
+    it('should hide the "ratings" buttons when the setting is false.', () => {
+      verifyVisibility('.micro-player .controls .rating-buttons', 'microButtonsRating');
+    });
+
+    it('should hide the "previous" button when the setting is false.', () => {
+      verifyVisibility('.micro-player .controls .previous', 'microButtonsPrevious');
+    });
+
+    it('should hide the "play / pause" button when the setting is false.', () => {
+      verifyVisibility('.micro-player .controls .play-pause', 'microButtonsPlayPause');
+    });
+
+    it('should hide the "next" button when the setting is false.', () => {
+      verifyVisibility('.micro-player .controls .next', 'microButtonsNext');
+    });
+
+    it('should hide the "show main window" button when the setting is false.', () => {
+      verifyVisibility('.micro-player .controls .window-buttons', 'microButtonsShowMainWindow');
+    });
+
+    it('should hide the "navigation" section when the "previous", "play/pause" and "next" buttons are hidden.', () => {
+      const selector = '.micro-player .controls .navigation-buttons';
+
+      expect(component.find(selector).exists(), 'initial').to.be.true;
+
+      mockEvent('settings:change:microButtonsPrevious', false);
+      expect(component.find(selector).exists(), 'hide previous').to.be.true;
+
+      mockEvent('settings:change:microButtonsPlayPause', false);
+      expect(component.find(selector).exists(), 'hide play/pause').to.be.true;
+
+      mockEvent('settings:change:microButtonsNext', false);
+      expect(component.find(selector).exists(), 'hide next').to.be.false;
+
+      mockEvent('settings:change:microButtonsPrevious', true);
+      expect(component.find(selector).exists(), 'show previous').to.be.true;
+
+      mockEvent('settings:change:microButtonsPrevious', false);
+      expect(component.find(selector).exists(), 'hide previous again').to.be.false;
+
+      mockEvent('settings:change:microButtonsPlayPause', true);
+      expect(component.find(selector).exists(), 'show play/pause').to.be.true;
+    });
+
+    it('should hide the "controls" section when all buttons are hidden.', () => {
+      const selector = '.micro-player .controls';
+
+      expect(component.find(selector).exists(), 'initial').to.be.true;
+
+      mockEvent('settings:change:microButtonsRating', false);
+      expect(component.find(selector).exists(), 'hide rating').to.be.true;
+
+      mockEvent('settings:change:microButtonsPrevious', false);
+      expect(component.find(selector).exists(), 'hide previous').to.be.true;
+
+      mockEvent('settings:change:microButtonsPlayPause', false);
+      expect(component.find(selector).exists(), 'hide play/pause').to.be.true;
+
+      mockEvent('settings:change:microButtonsNext', false);
+      expect(component.find(selector).exists(), 'hide next').to.be.true;
+
+      mockEvent('settings:change:microButtonsShowMainWindow', false);
+      expect(component.find(selector).exists(), 'hide show main window').to.be.false;
+
+      mockEvent('settings:change:microButtonsNext', true);
+      expect(component.find(selector).exists(), 'show next').to.be.true;
+
+      mockEvent('settings:change:microButtonsNext', false);
+      expect(component.find(selector).exists(), 'hide next again').to.be.false;
+
+      mockEvent('settings:change:microButtonsRating', true);
+      expect(component.find(selector).exists(), 'show rating').to.be.true;
     });
   });
 });

--- a/test/electron-renderer/ui/pages/PlayerPage_spec.js
+++ b/test/electron-renderer/ui/pages/PlayerPage_spec.js
@@ -78,6 +78,11 @@ describe('<PlayerPage />', () => {
     }, 1200);
   });
 
+  it('should fire "app:loading" when mounted', () => {
+    mount(<PlayerPage />);
+    expect(fired['app:loading']).to.be.ok;
+  });
+
   it('should fire "app:loaded" when the webview stops loading', (done) => {
     const component = mount(<PlayerPage />);
     component.instance()._didStopLoading();

--- a/test/electron-renderer/ui/pages/PlayerPage_spec.js
+++ b/test/electron-renderer/ui/pages/PlayerPage_spec.js
@@ -78,6 +78,15 @@ describe('<PlayerPage />', () => {
     }, 1200);
   });
 
+  it('should fire "app:loaded" when the webview stops loading', (done) => {
+    const component = mount(<PlayerPage />);
+    component.instance()._didStopLoading();
+    setTimeout(() => {
+      expect(fired['app:loaded']).to.be.ok;
+      done();
+    }, 1200);
+  });
+
   it('should persist GPM URLS on navigate events', () => {
     const component = mount(<PlayerPage />);
     component.instance().ready = true;

--- a/test/electron-renderer/ui/tabs/MicroTab_spec.js
+++ b/test/electron-renderer/ui/tabs/MicroTab_spec.js
@@ -1,0 +1,17 @@
+/* eslint-disable no-unused-expressions */
+
+import React from 'react';
+import chai from 'chai';
+import { mount } from 'enzyme';
+
+import MicroTab from '../../../../build/renderer/ui/components/settings/tabs/MicroTab';
+import materialUIContext from '../_materialUIContext';
+
+chai.should();
+
+describe('<MicroTab />', () => {
+  it('should render a SettingsTabWrapper', () => {
+    const component = mount(<MicroTab />, materialUIContext);
+    component.find('SettingsTabWrapper').length.should.be.equal(1);
+  });
+});

--- a/test/electron/PlaybackAPI_spec.js
+++ b/test/electron/PlaybackAPI_spec.js
@@ -96,7 +96,6 @@ describe('PlaybackAPI', () => {
   shouldUpdatePropTest('getRating', '_setRating', { liked: true, disliked: false }, '5');
   shouldUpdatePropTest('getRating', '_setRating', { liked: false, disliked: true }, '1');
   shouldUpdatePropTest('getLibrary', '_setLibrary', 'NEW_VALUE');
-  shouldUpdatePropTest('isPlaying', '_setPlaying', true);
   shouldUpdatePropTest('currentSong', '_setPlaybackSong', { title: '', artist: '', album: '', albumArt: '' }, '', '', '', '');
   shouldUpdatePropTest('getPlaylists', '_setPlaylists', ['foo', 'bar']);
   shouldUpdatePropTest('getQueue', '_setQueue', ['dumb', 'queue']);
@@ -106,6 +105,20 @@ describe('PlaybackAPI', () => {
   shouldUpdatePropTest('getResults', '_setResults', 'No results here :)');
   shouldUpdatePropTest('currentTime', '_setTime', { current: 100, total: 200 }, 100, 200);
   shouldUpdatePropTest('getVolume', '_setVolume', 33);
+
+  [
+    ['playback:isPlaying', true, false],
+    ['playback:isPaused', false, true],
+    ['playback:isStopped', false, false],
+  ].forEach(([event, playing, paused]) => {
+    it(`should set isPlaying to ${playing} and isPaused to ${paused} when "${event}" is received.`, () => {
+      // Set the initial state to the opposite of what we expect.
+      PlaybackAPI._setState(!playing, !paused);
+      Emitter.emit(event);
+      expect(PlaybackAPI.isPlaying(), 'isPlaying').to.equal(playing);
+      expect(PlaybackAPI.isPaused(), 'isPaused').to.equal(paused);
+    });
+  });
 
   describe('when creating a new PlaybackAPI', () => {
     given(gpmIpcEvents).it('should hook into GPM IPC event: ', (ipcEventName) => {

--- a/test/electron/microPlayer/MicroPlayerBoundsManager_spec.js
+++ b/test/electron/microPlayer/MicroPlayerBoundsManager_spec.js
@@ -1,0 +1,280 @@
+/* eslint-disable no-unused-expressions */
+
+import { screen } from 'electron';
+import chai from 'chai';
+import EventEmitter from 'events';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import { MicroPlayerBoundsManager } from '../../../src/main/features/core/microPlayer/MicroPlayerBoundsManager';
+
+const expect = chai.use(sinonChai).expect;
+
+describe('MicroPlayerBoundsManager', () => {
+  let window;
+  let sandbox;
+  let clock;
+  let manager;
+  let settings;
+
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create();
+    clock = sandbox.useFakeTimers();
+
+    window = new EventEmitter();
+    window.setPosition = sinon.stub();
+    window.getPosition = sinon.stub().returns([0, 0]);
+    window.getSize = sinon.stub().returns([100, 100]);
+    window.getBounds = () => ({
+      x: window.getPosition()[0],
+      y: window.getPosition()[1],
+      width: window.getSize()[0],
+      height: window.getSize()[1],
+    });
+
+    settings = {
+      size: [0, 0],
+      position: [0, 0],
+    };
+  });
+
+  describe('ensure on screen', () => {
+    function verifyAdjustment(originalPosition, size, screenBounds, adjustedPosition) {
+      settings.position = originalPosition;
+      window.getSize.returns(size);
+
+      const getDisplayMatching = sandbox.stub(screen, 'getDisplayMatching').returns({
+        bounds: screenBounds,
+      });
+
+      manager = new MicroPlayerBoundsManager(window, settings);
+
+      expect(getDisplayMatching).to.have.been.calledWith({
+        x: originalPosition[0],
+        y: originalPosition[1],
+        width: size[0],
+        height: size[1],
+      });
+
+      expect(window.setPosition).to.have.been.calledWith(...adjustedPosition);
+    }
+
+    it('should position the window at the top of the screen with the main window when no position has been saved.', () => {
+      settings.position = undefined;
+      window.getSize.returns([100, 200]);
+
+      const getDisplayMatching = sandbox.stub(screen, 'getDisplayMatching').returns({
+        bounds: { x: 400, y: 600, width: 1000, height: 2000 },
+      });
+
+      global.WindowManager = {
+        getAll: sinon.stub().returns([{
+          getBounds: () => ({ x: 1, y: 2, width: 3, height: 4 }),
+        }]),
+      };
+
+      manager = new MicroPlayerBoundsManager(window, settings);
+
+      expect(global.WindowManager.getAll).to.have.been.calledWith('main');
+      expect(getDisplayMatching).to.have.been.calledWith({ x: 1, y: 2, width: 3, height: 4 });
+      expect(window.setPosition).to.have.been.calledWith(850, 600);
+    });
+
+    it('should move the window down when it is above the top of the screen.', () => {
+      verifyAdjustment(
+        [800, 280],
+        [100, 200],
+        { x: 400, y: 300, width: 1000, height: 2000 },
+        [800, 300]
+      );
+    });
+
+    it('should move the window up when it is below the bottom of the screen.', () => {
+      verifyAdjustment(
+        [800, 2150],
+        [100, 200],
+        { x: 400, y: 300, width: 1000, height: 2000 },
+        [800, 2100]
+      );
+    });
+
+    it('should move the window to the right when the left edge is off screen.', () => {
+      verifyAdjustment(
+        [390, 800],
+        [100, 200],
+        { x: 400, y: 300, width: 1000, height: 2000 },
+        [400, 800]
+      );
+    });
+
+    it('should move the window to the left when the right edge is off screen.', () => {
+      verifyAdjustment(
+        [1310, 800],
+        [100, 200],
+        { x: 400, y: 300, width: 1000, height: 2000 },
+        [1300, 800]
+      );
+    });
+  });
+
+  describe('saving', () => {
+    function verifySettings(position, size) {
+      expect({ position: settings.position, size: settings.size }).to.deep.equal({
+        position,
+        size,
+      });
+    }
+
+    beforeEach(() => {
+      sandbox.stub(screen, 'getDisplayMatching').returns({
+        bounds: { x: 0, y: 0, width: 1000, height: 1000 },
+      });
+
+      settings.position = [0, 0];
+      settings.size = [100, 100];
+      window.getSize.returns([100, 100]);
+
+      manager = new MicroPlayerBoundsManager(window, settings);
+    });
+
+    it('should save the size and position one second after the window is moved.', () => {
+      window.getPosition.returns([20, 30]);
+      window.emit('move');
+
+      clock.tick(999);
+      verifySettings([0, 0], [100, 100]);
+
+      clock.tick(1);
+      verifySettings([20, 30], [100, 100]);
+    });
+
+    it('should save the size and position one second after the window is resized.', () => {
+      window.getSize.returns([80, 120]);
+      window.emit('resize');
+
+      clock.tick(999);
+      verifySettings([0, 0], [100, 100]);
+
+      clock.tick(1);
+      verifySettings([0, 0], [80, 120]);
+    });
+
+    it('should debounce window moving and resizing.', () => {
+      window.getSize.returns([50, 70]);
+      window.emit('resize');
+
+      clock.tick(800);
+
+      window.getPosition.returns([25, 60]);
+      window.emit('move');
+
+      clock.tick(200);
+      verifySettings([0, 0], [100, 100]);
+
+      clock.tick(800);
+      verifySettings([25, 60], [50, 70]);
+    });
+
+    it('should cancel saving when the window is closed.', () => {
+      window.getSize.returns([50, 70]);
+      window.emit('resize');
+
+      clock.tick(500);
+      window.emit('closed');
+
+      clock.tick(1000);
+      verifySettings([0, 0], [100, 100]);
+    });
+  });
+
+  describe('snapping', () => {
+    function verifySnap(expectedPosition) {
+      clock.tick(249);
+      expect(window.setPosition).to.have.not.been.called;
+
+      clock.tick(1);
+      expect(window.setPosition).to.have.been.calledWith(...expectedPosition);
+    }
+
+    beforeEach(() => {
+      sandbox.stub(screen, 'getDisplayMatching').returns({
+        bounds: { x: 200, y: 400, width: 600, height: 800 },
+      });
+
+      settings.position = [300, 500];
+      settings.size = [100, 100];
+      window.getSize.returns([100, 100]);
+
+      manager = new MicroPlayerBoundsManager(window, settings);
+
+      window.setPosition.reset();
+    });
+
+    it('should not snap to the top of the screen after the window is moved but is not near the top of the screen.', () => {
+      window.getPosition.returns([300, 410]);
+      window.emit('move');
+      clock.tick(10000);
+      expect(window.setPosition).to.have.not.been.called;
+    });
+
+    it('should snap to the top of the screen after the window is moved close to the top of the screen.', () => {
+      window.getPosition.returns([300, 405]);
+      window.emit('move');
+      verifySnap([300, 400]);
+    });
+
+    it('should snap to the top of the screen after the window is moved above the top of the screen.', () => {
+      window.getPosition.returns([300, 390]);
+      window.emit('move');
+      verifySnap([300, 400]);
+    });
+
+    it('should not snap to the bottom of the screen after the window is moved but is not near the bottom of the screen.', () => {
+      window.getPosition.returns([300, 1090]);
+      window.emit('move');
+      clock.tick(10000);
+      expect(window.setPosition).to.have.not.been.called;
+    });
+
+    it('should snap to the bottom of the screen after the window is moved close to the bottom of the screen.', () => {
+      window.getPosition.returns([300, 1095]);
+      window.emit('move');
+      verifySnap([300, 1100]);
+    });
+
+    it('should snap to the bottom of the screen after the window is moved beloe the bottom of the screen.', () => {
+      window.getPosition.returns([300, 1110]);
+      window.emit('move');
+      verifySnap([300, 1100]);
+    });
+  });
+
+  it('should remove window listeners when disposed.', () => {
+    settings.position = [0, 0];
+    window.getSize.returns([100, 100]);
+
+    manager = new MicroPlayerBoundsManager(window, settings);
+
+    window.getSize.returns([50, 70]);
+    window.emit('resize');
+    clock.tick(1000);
+
+    expect(settings.size).to.deep.equal([50, 70]);
+
+    manager.dispose();
+
+    window.getSize.returns([20, 40]);
+    window.emit('resize');
+    clock.tick(1000);
+
+    expect(settings.size).to.deep.equal([50, 70]);
+  });
+
+  afterEach(() => {
+    if (manager) {
+      manager.dispose();
+      manager = undefined;
+    }
+
+    sandbox.restore();
+  });
+});

--- a/test/electron/microPlayer/MicroPlayerController_spec.js
+++ b/test/electron/microPlayer/MicroPlayerController_spec.js
@@ -1,0 +1,86 @@
+/* eslint-disable no-unused-expressions */
+
+import chai from 'chai';
+import EventEmitter from 'events';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import { MicroPlayerController } from '../../../src/main/features/core/microPlayer/MicroPlayerController';
+
+const expect = chai.use(sinonChai).expect;
+
+describe('MicroPlayerController', () => {
+  let sandbox;
+  let id;
+  let controller;
+  let settings;
+  let window;
+
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create();
+
+    id = Symbol();
+
+    global.Emitter = new EventEmitter();
+    global.PlaybackAPI = new EventEmitter();
+    global.WindowManager = {
+      add: () => id,
+      close: sinon.stub(),
+    };
+
+    settings = {
+      enabled: true,
+      position: [0, 0],
+      size: [0, 0],
+    };
+
+    window = new EventEmitter();
+    window.getSize = () => [0, 0];
+    window.getPosition = () => [0, 0];
+    window.setPosition = () => undefined;
+    window.showInactive = () => undefined;
+    window.setClosable = sinon.stub();
+
+    // Stub the internal method that creates the window because
+    // we don't want a real window to be created for these tests.
+    sandbox.stub(MicroPlayerController.prototype, '_createWindow').returns(window);
+  });
+
+  afterEach(() => {
+    if (controller) {
+      controller.dispose();
+      controller = undefined;
+    }
+
+    sandbox.restore();
+  });
+
+  it('should prevent the window from closing.', () => {
+    controller = new MicroPlayerController(settings);
+
+    const args = { preventDefault: sinon.stub() };
+    window.emit('close', args);
+
+    expect(args.preventDefault).to.have.been.calledOnce;
+  });
+
+  it('should allow the window to be closed when the controller is disposed.', () => {
+    const args = { preventDefault: sinon.stub() };
+    let closedID = undefined;
+
+    WindowManager.close = (windowID) => {
+      closedID = windowID;
+      window.emit('close', args);
+    };
+
+    controller = new MicroPlayerController(settings);
+
+    expect(window.setClosable).to.have.not.been.called;
+    expect(closedID).to.be.undefined;
+
+    controller.dispose();
+
+    expect(window.setClosable).to.have.been.calledWith(true);
+    expect(closedID).to.equal(id);
+    expect(args.preventDefault).to.have.not.been.called;
+  });
+});

--- a/test/electron/microPlayer/MicroPlayerEventAdapter_spec.js
+++ b/test/electron/microPlayer/MicroPlayerEventAdapter_spec.js
@@ -1,0 +1,243 @@
+/* eslint-disable no-unused-expressions */
+
+import chai from 'chai';
+import EventEmitter from 'events';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import { MicroPlayerEventAdapter } from '../../../src/main/features/core/microPlayer/MicroPlayerEventAdapter';
+import { setAppLoaded } from '../../../src/main/features/core/microPlayer/_applicationState';
+
+const expect = chai.use(sinonChai).expect;
+
+describe('MicroPlayerEventAdapter', () => {
+  let playback;
+  let events;
+  let windowID;
+  let adapter;
+
+  function getEvent(name) {
+    return events.filter((x) => x.event === name)[0];
+  }
+
+  beforeEach(() => {
+    windowID = Symbol();
+    events = [];
+
+    global.Emitter = new EventEmitter();
+    global.Emitter.sendToWindow = (window, event, data) => {
+      events.push({ window, event, data });
+    };
+
+    playback = new EventEmitter();
+    playback.isPlaying = () => false;
+    playback.isPaused = () => false;
+    playback.getRating = () => ({ liked: false, disliked: false });
+    playback.currentSong = () => null;
+    global.PlaybackAPI = playback;
+
+    setAppLoaded(true);
+  });
+
+  it('should send "app:loaded" message when app is already loaded when once micro player is ready.', () => {
+    setAppLoaded(true);
+    adapter = new MicroPlayerEventAdapter(windowID);
+    expect(events).to.be.empty;
+    Emitter.emit('micro:ready');
+
+    // The app:loaded event should always be the first event.
+    expect(events[0]).to.deep.equal({ window: windowID, event: 'app:loaded', data: undefined });
+  });
+
+  it('should not send "app:loaded" message when app is not already loaded.', () => {
+    setAppLoaded(false);
+    adapter = new MicroPlayerEventAdapter(windowID);
+    expect(events).to.be.empty;
+    Emitter.emit('micro:ready');
+    expect(events.map((x) => x.event)).to.not.contain('app:loaded');
+  });
+
+  it('should not forward "app:loaded" message.', () => {
+    setAppLoaded(false);
+    adapter = new MicroPlayerEventAdapter(windowID);
+    Emitter.emit('micro:ready');
+    expect(events.map((x) => x.event)).to.not.contain('app:loaded');
+
+    // Fire the "app:loaded" event after the micro player is ready.
+    // The adapter should not forward this event to the micro player.
+    Emitter.emit('app:loaded');
+    expect(events.map((x) => x.event)).to.not.contain('app:loaded');
+  });
+
+  it('should send "playback:isPlaying" when micro player is ready and app is playing.', () => {
+    playback.isPlaying = () => true;
+    playback.isPaused = () => false;
+
+    adapter = new MicroPlayerEventAdapter(windowID);
+    expect(events).to.be.empty;
+    Emitter.emit('micro:ready');
+    expect(getEvent('playback:isPlaying')).to.exist;
+    expect(getEvent('playback:isPaused')).to.not.exist;
+    expect(getEvent('playback:isStopped')).to.not.exist;
+  });
+
+  it('should send "playback:isPaused" when micro player is ready and app is paused.', () => {
+    playback.isPlaying = () => false;
+    playback.isPaused = () => true;
+
+    adapter = new MicroPlayerEventAdapter(windowID);
+    expect(events).to.be.empty;
+    Emitter.emit('micro:ready');
+    expect(getEvent('playback:isPlaying')).to.not.exist;
+    expect(getEvent('playback:isPaused')).to.exist;
+    expect(getEvent('playback:isStopped')).to.not.exist;
+  });
+
+  it('should send "playback:isStopped" when micro player is ready and app is stopped.', () => {
+    playback.isPlaying = () => false;
+    playback.isPaused = () => false;
+
+    adapter = new MicroPlayerEventAdapter(windowID);
+    expect(events).to.be.empty;
+    Emitter.emit('micro:ready');
+    expect(getEvent('playback:isPlaying')).to.not.exist;
+    expect(getEvent('playback:isPaused')).to.not.exist;
+    expect(getEvent('playback:isStopped')).to.exist;
+  });
+
+  it('should send the current rating when micro player is ready.', () => {
+    playback.getRating = () => ({ liked: true, disliked: false });
+
+    adapter = new MicroPlayerEventAdapter(windowID);
+    expect(events).to.be.empty;
+    Emitter.emit('micro:ready');
+    expect(getEvent('PlaybackAPI:change:rating')).to.deep.equal({
+      event: 'PlaybackAPI:change:rating',
+      window: windowID,
+      data: { liked: true, disliked: false },
+    });
+  });
+
+  it('should send the current track when micro player is ready.', () => {
+    playback.currentSong = () => ({ artist: 'foo', album: 'bar' });
+
+    adapter = new MicroPlayerEventAdapter(windowID);
+    expect(events).to.be.empty;
+    Emitter.emit('micro:ready');
+    expect(getEvent('PlaybackAPI:change:track')).to.deep.equal({
+      event: 'PlaybackAPI:change:track',
+      window: windowID,
+      data: { artist: 'foo', album: 'bar' },
+    });
+  });
+
+  [
+    'playback:isPlaying',
+    'playback:isPaused',
+    'playback:isStopped',
+  ].forEach((event) => {
+    it(`should forward the "${event}" event to the micro player.`, () => {
+      adapter = new MicroPlayerEventAdapter(windowID);
+      Emitter.emit('micro:ready');
+
+      // Reset the captured events so that we ignore
+      // any of the initial events that were emitted.
+      events = [];
+
+      expect(getEvent(event)).to.not.exist;
+      Emitter.emit(event);
+      expect(getEvent(event)).to.exist;
+    });
+  });
+
+  [
+    { event: 'change:rating', data: { liked: false, disliked: true } },
+    { event: 'change:track', data: { artist: 'foo' } },
+  ].forEach(({ event, data }) => {
+    it(`should forward the "${event}" event from the PlaybackAPI to the micro player.`, () => {
+      adapter = new MicroPlayerEventAdapter(windowID);
+      Emitter.emit('micro:ready');
+
+      // Reset the captured events so that we ignore
+      // any of the initial events that were emitted.
+      events = [];
+
+      expect(getEvent(`PlaybackAPI:${event}`)).to.not.exist;
+      playback.emit(event, data);
+      expect(getEvent(`PlaybackAPI:${event}`)).to.deep.equal({
+        event: `PlaybackAPI:${event}`,
+        window: windowID,
+        data,
+      });
+    });
+  });
+
+  it('should remove event listeners when disposed.', () => {
+    adapter = new MicroPlayerEventAdapter(windowID);
+    Emitter.emit('micro:ready');
+
+    // Confirm that an event is forwarded before being disposed.
+    events = [];
+    Emitter.emit('playback:isPlaying');
+    expect(events).to.not.be.empty;
+
+    // Dispose the adapter and reset the captured events list.
+    events = [];
+    adapter.dispose();
+
+    // Confirm that the event is not forwarded after being disposed.
+    Emitter.emit('playback:isPlaying');
+    expect(events).to.be.empty;
+  });
+
+  describe('micro:showMainWindow', () => {
+    let window;
+
+    beforeEach(() => {
+      window = {
+        isMinimized: () => true,
+        setSkipTaskbar: sinon.spy(),
+        restore: sinon.spy(),
+        show: sinon.spy(),
+        focus: sinon.spy(),
+      };
+
+      global.WindowManager = {
+        getAll: (name) => { // eslint-disable-line arrow-body-style
+          return name === 'main' ? [window] : [];
+        },
+      };
+
+      adapter = new MicroPlayerEventAdapter(windowID);
+      Emitter.emit('micro:ready');
+    });
+
+    it('should show the main window when requested by the micro player.', () => {
+      Emitter.emit('micro:showMainWindow');
+
+      expect(window.setSkipTaskbar).to.have.been.calledWithExactly(false);
+      expect(window.show).to.have.been.called;
+      expect(window.focus).to.have.been.called;
+    });
+
+    it('should not restore the main window if it is not minimized.', () => {
+      window.isMinimized = () => false;
+      Emitter.emit('micro:showMainWindow');
+      expect(window.restore).to.have.not.been.called;
+      expect(window.show).to.have.been.called;
+    });
+
+    it('should restore the main window if it is minimized.', () => {
+      window.isMinimized = () => true;
+      Emitter.emit('micro:showMainWindow');
+      expect(window.restore).to.have.been.called;
+      expect(window.show).to.have.been.called;
+    });
+  });
+
+  afterEach(() => {
+    if (adapter) {
+      adapter.dispose();
+      adapter = undefined;
+    }
+  });
+});

--- a/test/electron/microPlayer/MicroPlayerSettings_spec.js
+++ b/test/electron/microPlayer/MicroPlayerSettings_spec.js
@@ -1,0 +1,75 @@
+/* eslint-disable no-unused-expressions */
+
+import { expect } from 'chai';
+import { MicroPlayerSettings } from '../../../src/main/features/core/microPlayer/MicroPlayerSettings';
+
+describe('MicroPlayerSettings', () => {
+  /** @type {MicroPlayerSettings} */
+  let settings;
+  let store;
+
+  function testProperty(setter, getter, key, values) {
+    for (const value of values) {
+      setter((value));
+      expect(store[key]).to.equal(value);
+      expect(getter((value))).to.equal(value);
+    }
+  }
+
+  before(() => {
+    global.Settings = {
+      get: (key, defaultValue) => store[key] || defaultValue,
+      set: (key, value) => (store[key] = value),
+    };
+  });
+
+  beforeEach(() => {
+    settings = new MicroPlayerSettings();
+    store = {};
+  });
+
+  describe('enabled', () => {
+    it('should be false by default.', () => {
+      expect(settings.enabled).to.be.false;
+    });
+
+    it('should get and set the value.', () => {
+      testProperty(
+        (value) => (settings.enabled = value),
+        () => settings.enabled,
+        'microplayer-enabled',
+        [true, false]
+      );
+    });
+  });
+
+  describe('size', () => {
+    it('should be 400x40 by default.', () => {
+      expect(settings.size).to.deep.equal([400, 40]);
+    });
+
+    it('should get and set the value.', () => {
+      testProperty(
+        (value) => (settings.size = value),
+        () => settings.size,
+        'microplayer-size',
+        [[100, 10], [200, 50]]
+      );
+    });
+  });
+
+  describe('position', () => {
+    it('should be undefined by default.', () => {
+      expect(settings.position).to.be.undefined;
+    });
+
+    it('should get and set the value.', () => {
+      testProperty(
+        (value) => (settings.position = value),
+        () => settings.position,
+        'microplayer-position',
+        [[10, 20], [300, 100]]
+      );
+    });
+  });
+});

--- a/test/electron/webSocketAPI_spec.js
+++ b/test/electron/webSocketAPI_spec.js
@@ -192,7 +192,7 @@ describe('WebSocketAPI', () => {
         });
       };
 
-      shouldUpdateTest('playState', '_setPlaying', true);
+      shouldUpdateTest('playState', '_setState', [true, false], true);
       shouldUpdateTest('shuffle', '_setShuffle', 'ALL_SHUFFLE');
       shouldUpdateTest('repeat', '_setRepeat', 'SINGLE_REPEAT');
       shouldUpdateTest('playlists', '_setPlaylists',


### PR DESCRIPTION
Implementation of #701. 

# 📔 Overview 

This is a "micro" player that provides similar functionality to the mini player with a few key differences.

* This micro player is displayed in a separate window. Unlike the mini player, you don't need to close the micro player to get back to the main window.
* The micro player has a much smaller height, so it's suitable for placing at the top or bottom of the screen without getting in the road too much.
* The track information is always displayed.
* The _Thumbs up_ and _Thumbs down_ buttons are always displayed.


# 🎨 Screenshots 

Turn it on or off from the side menu:
![image](https://user-images.githubusercontent.com/10321525/70128503-aeca8680-16c8-11ea-9e15-95b0431c1fe8.png)

On Windows (see limitations below):
![micro-player](https://user-images.githubusercontent.com/10321525/68464735-d7439a00-025c-11ea-8deb-d981a329dfda.gif)

On Linux:
![micro-player-linux](https://user-images.githubusercontent.com/10321525/68466333-e841da80-025f-11ea-8cbc-dcfee4651b60.gif)

With custom styles:
![dark-theme](https://user-images.githubusercontent.com/10321525/68465062-736da100-025d-11ea-9eda-a691611cbfd5.png)

# 🔧 Application changes

To allow the micro player window to know about what's happening in the main player, I've had to make some changes to the rest of the application.

## Playback API

The data in the playback API now has a `paused` property. I needed to add this to allow the micro player to know whether the player is stopped, paused or playing when the micro player first opens.

❓ Does this require an increase to the API version? It's This is an _addition_ to the public interface, so I'm assuming that it's _not_ considered a breaking change.

## Remove listeners from Emitter

There's an adapter class that forwards events from the `Emitter` class through to the micro player window. When the micro player closes, the event listeners need to be removed. I've added an `Emitter.removeListener()` function that just calls through to the underlying `ipcMain` object.

## "Application loaded" event

The micro player can open before the main window has finished loading GPM. I've made the `PlayerPage` emit an `"app:loaded"` event so that the micro player can show the loading indicator while the main window is still loading.

# 🔨 Testing

I developed it on Windows 10, so it's had plenty of testing on Windows, and I've poked it a _little_ bit on Linux - enough to find a few issues with it, but not enough to be super-confident with it. It has not been tested on macOS.

# ⚡️ Limitations

On Windows, it cannot be resized smaller than 39px high. This is due to a bug/limitation in Electron v3. This is fixed in Electron v6+.

# ☑️ To Do List

- [ ] Testing on Linux
- [ ] Testing on macOS
- [x] Fix bug with event listeners not being removed.

# What's next?

I've created this PR as a draft so that I can get some feedback on it. I haven't used Electron or React before, so please let me know if there's anything that I've done wrong on that side of things. 😁 

As I mentioned above, I've only really tested this on Windows with just some simple testing on Linux inside a VM, so it would be greatly appreciated if some people running Linux and macOS could install/build this and test it out.

Let me know what you think! ✌️