### PR TITLE
Emit "load styles" events when file is not specified to clear custom styles

### DIFF
--- a/src/main/features/core/customStyle.js
+++ b/src/main/features/core/customStyle.js
@@ -6,6 +6,8 @@ Emitter.on('FetchMainAppCustomStyles', () => {
     fs.readFile(mainAppPath, 'utf8', (err, css) => {
       Emitter.sendToAll('LoadMainAppCustomStyles', err ? '' : css);
     });
+  } else {
+    Emitter.sendToAll('LoadMainAppCustomStyles', '');
   }
 });
 
@@ -15,5 +17,7 @@ Emitter.on('FetchGPMCustomStyles', () => {
     fs.readFile(gpmPath, 'utf8', (err, css) => {
       Emitter.sendToGooglePlayMusic('LoadGPMCustomStyles', err ? '' : css);
     });
+  } else {
+    Emitter.sendToGooglePlayMusic('LoadGPMCustomStyles', '');
   }
 });


### PR DESCRIPTION
If you clear the styles in the editor, the custom styles that have been applied are not cleared. You need to restart the application to have them cleared.

This PR fixes this by emitting the corresponding "load styles" event if the file name is blank or if the file does not exist.