### PR TITLE
Fix translation updating

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
     "coveralls": "^2.11.12",
     "cross-env": "^2.0.1",
     "devtron": "^1.0.1",
+    "diff": "^4.0.1",
     "electron": "3.1.8",
     "electron-devtools-installer": "^2.2.4",
     "electron-mocha": "^3.0.0",

--- a/src/_locales/cs.json
+++ b/src/_locales/cs.json
@@ -134,6 +134,7 @@
   "settings-options-style-dialog-button": "",
   "settings-options-style-dialog-css-files": "",
   "settings-options-style-dialog-all-files": "",
+
   "slack-token-label": "",
   "slack-token-placeholder": "",
 

--- a/src/_locales/da.json
+++ b/src/_locales/da.json
@@ -11,6 +11,8 @@
   "button-text-lets-do-this": "La' os gøre det!!",
   "button-text-lets-go": "Kom igang!!",
   "button-text-not-now": "Ikke lige nu",
+  "button-text-ytm-switch": "",
+  "button-text-gpm-switch": "",
 
   "label-about": "Om",
   "label-alarm": "Alarm",
@@ -35,8 +37,6 @@
   "lastfm-login-not-authorized": "Dit login blev ikke godkendt",
   "lastfm-logout-button-text": "Log ud af Last.FM",
   "lastfm-map-thumbs-up-to-heart": "",
-  "button-text-ytm-switch": "",
-  "button-text-gpm-switch": "",
 
   "listenbrainz-label-user-token": "",
   "listenbrainz-token-here": "",
@@ -134,6 +134,7 @@
   "settings-options-style-dialog-button": "Indlæs CSS",
   "settings-options-style-dialog-css-files": "CSS filer",
   "settings-options-style-dialog-all-files": "Alle filer",
+
   "slack-token-label": "",
   "slack-token-placeholder": "",
 

--- a/src/_locales/de.json
+++ b/src/_locales/de.json
@@ -134,6 +134,7 @@
   "settings-options-style-dialog-button": "CSS laden",
   "settings-options-style-dialog-css-files": "CSS-Dateien",
   "settings-options-style-dialog-all-files": "Alle Dateien",
+
   "slack-token-label": "",
   "slack-token-placeholder": "",
 

--- a/src/_locales/es-ES.json
+++ b/src/_locales/es-ES.json
@@ -134,6 +134,7 @@
   "settings-options-style-dialog-button": "Cargar CSS",
   "settings-options-style-dialog-css-files": "Ficheros CSS",
   "settings-options-style-dialog-all-files": "Todos los Ficheros",
+
   "slack-token-label": "Ingresa tu token de usuario Slack (puedes encontrarlo en $1)",
   "slack-token-placeholder": "Token Slack",
 

--- a/src/_locales/hu.json
+++ b/src/_locales/hu.json
@@ -134,6 +134,7 @@
   "settings-options-style-dialog-button": "CSS betöltése",
   "settings-options-style-dialog-css-files": "CSS Fájlok",
   "settings-options-style-dialog-all-files": "Összes fájl",
+
   "slack-token-label": "",
   "slack-token-placeholder": "",
 

--- a/src/_locales/it.json
+++ b/src/_locales/it.json
@@ -134,6 +134,7 @@
   "settings-options-style-dialog-button": "Carica CSS",
   "settings-options-style-dialog-css-files": "File CSS",
   "settings-options-style-dialog-all-files": "Tutti i file",
+
   "slack-token-label": "Inserisci il tuo token utente per slack (puoi trovarlo all'indirizzo $1)",
   "slack-token-placeholder": "Token slack",
 

--- a/src/_locales/ja.json
+++ b/src/_locales/ja.json
@@ -134,6 +134,7 @@
   "settings-options-style-dialog-button": "CSSを読み込む",
   "settings-options-style-dialog-css-files": "CSSファイル",
   "settings-options-style-dialog-all-files": "全てのファイル",
+
   "slack-token-label": "Slackのトークンを入力してください",
   "slack-token-placeholder": "トークンを入力してください",
 

--- a/src/_locales/ka.json
+++ b/src/_locales/ka.json
@@ -100,8 +100,8 @@
   "settings-option-enable-taskbar-progress": "ვაჩვენოთ ტრეკის პროგრესი დავალებების პანელში",
   "settings-option-enable-win10-media-service": "Windows 10-ის სისტემური მედიასერვისის ჩართვა",
   "settings-option-enable-win10-media-service-details": "მიმდინარე ტრეკის დასახელება გამოჩნდება ბლოკირების ფანჯარაში",
-  "settings-option-enable-win10-media-service-track-info": "ტრეკის ინფორმაციის Windows 10-ის ხმის ბარში ჩვენება",
   "settings-option-discord-rich-presence": "Discord Rich Presence ინტეგრაციის ჩართვა",
+  "settings-option-enable-win10-media-service-track-info": "ტრეკის ინფორმაციის Windows 10-ის ხმის ბარში ჩვენება",
   "settings-option-change-locale": "პროგრამის ენა",
 
   "settings-option-hotkey-explanation": "სტანდარტული მულტიმედიური ღილაკები მაინც იმუშავებს მიუხედავად ქვემოთ მოყვანილი დამატებითი ღილაკებისა.",

--- a/src/_locales/pirate.json
+++ b/src/_locales/pirate.json
@@ -134,6 +134,7 @@
   "settings-options-style-dialog-button": "",
   "settings-options-style-dialog-css-files": "",
   "settings-options-style-dialog-all-files": "",
+
   "slack-token-label": "",
   "slack-token-placeholder": "",
 

--- a/src/_locales/pl-PL.json
+++ b/src/_locales/pl-PL.json
@@ -134,6 +134,7 @@
   "settings-options-style-dialog-button": "Załaduj plik CSS",
   "settings-options-style-dialog-css-files": "Pliki CSS",
   "settings-options-style-dialog-all-files": "Wszystkie pliki",
+
   "slack-token-label": "Wpisz swój Slack token (znajdziesz go pod linkiem: $1)",
   "slack-token-placeholder": "Slack token",
 

--- a/src/_locales/pt-BR.json
+++ b/src/_locales/pt-BR.json
@@ -134,6 +134,7 @@
   "settings-options-style-dialog-button": "Carregar CSS",
   "settings-options-style-dialog-css-files": "Arquivos CSS",
   "settings-options-style-dialog-all-files": "Todos os arquivos",
+
   "slack-token-label": "",
   "slack-token-placeholder": "",
 

--- a/src/_locales/ro.json
+++ b/src/_locales/ro.json
@@ -134,6 +134,7 @@
   "settings-options-style-dialog-button": "Încarcă CSS",
   "settings-options-style-dialog-css-files": "Fișiere CSS",
   "settings-options-style-dialog-all-files": "Toate fișierele",
+
   "slack-token-label": "",
   "slack-token-placeholder": "",
 

--- a/src/_locales/ru.json
+++ b/src/_locales/ru.json
@@ -134,6 +134,7 @@
   "settings-options-style-dialog-button": "Загрузить CSS",
   "settings-options-style-dialog-css-files": "Файлы CSS",
   "settings-options-style-dialog-all-files": "Все файлы",
+
   "slack-token-label": "",
   "slack-token-placeholder": "",
 

--- a/src/_locales/sk.json
+++ b/src/_locales/sk.json
@@ -134,6 +134,7 @@
   "settings-options-style-dialog-button": "Načítať CSS",
   "settings-options-style-dialog-css-files": "CSS súbory",
   "settings-options-style-dialog-all-files": "Všetky súbory",
+
   "slack-token-label": "",
   "slack-token-placeholder": "",
 

--- a/src/_locales/sv.json
+++ b/src/_locales/sv.json
@@ -134,6 +134,7 @@
   "settings-options-style-dialog-button": "Ladda CSS",
   "settings-options-style-dialog-css-files": "CSS-filer",
   "settings-options-style-dialog-all-files": "Alla filer",
+
   "slack-token-label": "",
   "slack-token-placeholder": "",
 

--- a/src/_locales/ua.json
+++ b/src/_locales/ua.json
@@ -134,6 +134,7 @@
   "settings-options-style-dialog-button": "Завантажити CSS",
   "settings-options-style-dialog-css-files": "Файл CSS",
   "settings-options-style-dialog-all-files": "Всі файли",
+
   "slack-token-label": "",
   "slack-token-placeholder": "",
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2209,6 +2209,11 @@ diff@3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.2.0.tgz#c9ce393a4b7cbd0b058a725c93df299027868ff9"
 
+diff@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.1.tgz#0c667cb467ebbb5cea7f14f135cc2dba7780a8ff"
+  integrity sha512-s2+XdvhPCOF01LRQBC8hf4vhbVmI2CGS5aZnxLJlT5FtdhPCDFq80q++zK2KlrVorVDdL5BOGZ/VfLrVtYNF+Q==
+
 discord-rich-presence@^0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/discord-rich-presence/-/discord-rich-presence-0.0.7.tgz#e9e1779b8a2d4ac4690bfaaef896a8b3aa6c306c"


### PR DESCRIPTION
There's a bug in `vendor/update-translations.js` that results in it running out of memory due to the current state of some of the translation files. I'm not 100% sure, but I think it might be caused by some property keys being out of order in some of the locale files.

I've re-written this script to use the [`diff`](https://www.npmjs.com/package/diff) module, which makes it a lot simpler.

The logic is:
1. Read the `en-US.json` file and change all property values to an empty string.
2. Read the locale file being updated and keep the original lines.
3. Make a copy of those lines with all property values set to an empty string.
4. Compute the diff between the lines (without property values) from `en-US.json` and the lines (without property values) from the locale file.
5. For each diff segment:
    - If the segment has not changed, take the original lines from the locale file for that range of the diff.
    - If the segment has been "added", then it means the lines in the locale file should not be there, and they can be skipped over.
    - If the segment has been "removed", then it means the lines from `en-US.json` need to be added to the locale file.
6. After all diff segments have been processed, write the resulting set of lines back to the file.

I've also run the script to get all of the locale files back in sync.