### PR TITLE
Add error message and reload button when initial page fails to load

### DIFF
--- a/src/_locales/cs.json
+++ b/src/_locales/cs.json
@@ -76,6 +76,11 @@
   "playback-label-im-feeling-lucky": "",
   "playback-label-toggle-repeat": "",
 
+  "player-load-failed-gpm": "",
+  "player-load-failed-ytm": "",
+  "player-load-failed-retry": "",
+  "player-load-failed-countdown": "",
+
   "settings-requires-restart": "Vyžaduje restart",
 
   "settings-option-keep-sidebar-open": "",

--- a/src/_locales/da.json
+++ b/src/_locales/da.json
@@ -76,6 +76,11 @@
   "playback-label-im-feeling-lucky": "",
   "playback-label-toggle-repeat": "",
 
+  "player-load-failed-gpm": "",
+  "player-load-failed-ytm": "",
+  "player-load-failed-retry": "",
+  "player-load-failed-countdown": "",
+
   "settings-requires-restart": "Kræver genstart af GPMDP",
 
   "settings-option-keep-sidebar-open": "",

--- a/src/_locales/de.json
+++ b/src/_locales/de.json
@@ -76,6 +76,11 @@
   "playback-label-im-feeling-lucky": "",
   "playback-label-toggle-repeat": "",
 
+  "player-load-failed-gpm": "",
+  "player-load-failed-ytm": "",
+  "player-load-failed-retry": "",
+  "player-load-failed-countdown": "",
+
   "settings-requires-restart": "Erfordert einen Neustart",
 
   "settings-option-keep-sidebar-open": "Seitenleiste offen halten",

--- a/src/_locales/en-US.json
+++ b/src/_locales/en-US.json
@@ -76,6 +76,11 @@
   "playback-label-im-feeling-lucky": "I'm Feeling Lucky",
   "playback-label-toggle-repeat": "Toggle Repeat",
 
+  "player-load-failed-gpm": "Unable to load Google Play Music",
+  "player-load-failed-ytm": "Unable to load YouTube Music",
+  "player-load-failed-retry": "Try again",
+  "player-load-failed-countdown": "Reloading in $1...",
+
   "settings-requires-restart": "Requires restart",
 
   "settings-option-keep-sidebar-open": "Keep sidebar open",

--- a/src/_locales/es-ES.json
+++ b/src/_locales/es-ES.json
@@ -76,6 +76,11 @@
   "playback-label-im-feeling-lucky": "Me siento con suerte",
   "playback-label-toggle-repeat": "Alternar repetición",
 
+  "player-load-failed-gpm": "",
+  "player-load-failed-ytm": "",
+  "player-load-failed-retry": "",
+  "player-load-failed-countdown": "",
+
   "settings-requires-restart": "Requiere reiniciar",
 
   "settings-option-keep-sidebar-open": "Mantener la barra lateral abierta",

--- a/src/_locales/fr-FR.json
+++ b/src/_locales/fr-FR.json
@@ -76,6 +76,11 @@
   "playback-label-im-feeling-lucky": "J'ai de la chance",
   "playback-label-toggle-repeat": "",
 
+  "player-load-failed-gpm": "",
+  "player-load-failed-ytm": "",
+  "player-load-failed-retry": "",
+  "player-load-failed-countdown": "",
+
   "settings-requires-restart": "Besoin de redémarrer",
 
   "settings-option-keep-sidebar-open": "Garder le menu latéral ouvert",

--- a/src/_locales/hu.json
+++ b/src/_locales/hu.json
@@ -76,6 +76,11 @@
   "playback-label-im-feeling-lucky": "",
   "playback-label-toggle-repeat": "",
 
+  "player-load-failed-gpm": "",
+  "player-load-failed-ytm": "",
+  "player-load-failed-retry": "",
+  "player-load-failed-countdown": "",
+
   "settings-requires-restart": "Újraindítást igényel",
 
   "settings-option-keep-sidebar-open": "Tartsa nyitva az oldalsávot",

--- a/src/_locales/it.json
+++ b/src/_locales/it.json
@@ -76,6 +76,11 @@
   "playback-label-im-feeling-lucky": "Mi sento fortunato",
   "playback-label-toggle-repeat": "Attiva / Disattiva ripetizione",
 
+  "player-load-failed-gpm": "",
+  "player-load-failed-ytm": "",
+  "player-load-failed-retry": "",
+  "player-load-failed-countdown": "",
+
   "settings-requires-restart": "Richiede riavvio",
 
   "settings-option-keep-sidebar-open": "Mantieni la barra laterale aperta",

--- a/src/_locales/ja.json
+++ b/src/_locales/ja.json
@@ -76,6 +76,11 @@
   "playback-label-im-feeling-lucky": "I'm Feeling Lucky",
   "playback-label-toggle-repeat": "",
 
+  "player-load-failed-gpm": "",
+  "player-load-failed-ytm": "",
+  "player-load-failed-retry": "",
+  "player-load-failed-countdown": "",
+
   "settings-requires-restart": "再起動が必要です",
 
   "settings-option-keep-sidebar-open": "サイドバーを表示",

--- a/src/_locales/ka.json
+++ b/src/_locales/ka.json
@@ -76,6 +76,11 @@
   "playback-label-im-feeling-lucky": "გამიმართლებს!",
   "playback-label-toggle-repeat": "",
 
+  "player-load-failed-gpm": "",
+  "player-load-failed-ytm": "",
+  "player-load-failed-retry": "",
+  "player-load-failed-countdown": "",
+
   "settings-requires-restart": "საჭიროებს გადატვირთვას",
 
   "settings-option-keep-sidebar-open": "დარჩეს საიდბარი გახსნილი",

--- a/src/_locales/ko-KR.json
+++ b/src/_locales/ko-KR.json
@@ -76,6 +76,11 @@
   "playback-label-im-feeling-lucky": "I'm Feeling Lucky",
   "playback-label-toggle-repeat": "",
 
+  "player-load-failed-gpm": "",
+  "player-load-failed-ytm": "",
+  "player-load-failed-retry": "",
+  "player-load-failed-countdown": "",
+
   "settings-requires-restart": "재시작 필요",
 
   "settings-option-keep-sidebar-open": "사이드 바 표시",

--- a/src/_locales/nl-NL.json
+++ b/src/_locales/nl-NL.json
@@ -76,6 +76,11 @@
   "playback-label-im-feeling-lucky": "Ik doe een gok",
   "playback-label-toggle-repeat": "Herhalen aan/uit",
 
+  "player-load-failed-gpm": "",
+  "player-load-failed-ytm": "",
+  "player-load-failed-retry": "",
+  "player-load-failed-countdown": "",
+
   "settings-requires-restart": "Vereist herstart",
 
   "settings-option-keep-sidebar-open": "Zijbalk open houden",

--- a/src/_locales/pirate.json
+++ b/src/_locales/pirate.json
@@ -76,6 +76,11 @@
   "playback-label-im-feeling-lucky": "",
   "playback-label-toggle-repeat": "",
 
+  "player-load-failed-gpm": "",
+  "player-load-failed-ytm": "",
+  "player-load-failed-retry": "",
+  "player-load-failed-countdown": "",
+
   "settings-requires-restart": "Requires ye scuttle and relaunch",
 
   "settings-option-keep-sidebar-open": "",

--- a/src/_locales/pl-PL.json
+++ b/src/_locales/pl-PL.json
@@ -76,6 +76,11 @@
   "playback-label-im-feeling-lucky": "Szczęśliwy traf",
   "playback-label-toggle-repeat": "",
 
+  "player-load-failed-gpm": "",
+  "player-load-failed-ytm": "",
+  "player-load-failed-retry": "",
+  "player-load-failed-countdown": "",
+
   "settings-requires-restart": "Wymaga ponownego uruchomienia",
 
   "settings-option-keep-sidebar-open": "Utrzymuj boczne menu otwarte",

--- a/src/_locales/pt-BR.json
+++ b/src/_locales/pt-BR.json
@@ -76,6 +76,11 @@
   "playback-label-im-feeling-lucky": "Estou com sorte",
   "playback-label-toggle-repeat": "",
 
+  "player-load-failed-gpm": "",
+  "player-load-failed-ytm": "",
+  "player-load-failed-retry": "",
+  "player-load-failed-countdown": "",
+
   "settings-requires-restart": "Requer reinicialização",
 
   "settings-option-keep-sidebar-open": "Manter a barra lateral aberta",

--- a/src/_locales/ro.json
+++ b/src/_locales/ro.json
@@ -76,6 +76,11 @@
   "playback-label-im-feeling-lucky": "",
   "playback-label-toggle-repeat": "",
 
+  "player-load-failed-gpm": "",
+  "player-load-failed-ytm": "",
+  "player-load-failed-retry": "",
+  "player-load-failed-countdown": "",
+
   "settings-requires-restart": "Necesită repornirea aplicației",
 
   "settings-option-keep-sidebar-open": "Păstrează bara laterală deschisă",

--- a/src/_locales/ru.json
+++ b/src/_locales/ru.json
@@ -76,6 +76,11 @@
   "playback-label-im-feeling-lucky": "Мне повезёт!",
   "playback-label-toggle-repeat": "Изменить режим повтора",
 
+  "player-load-failed-gpm": "",
+  "player-load-failed-ytm": "",
+  "player-load-failed-retry": "",
+  "player-load-failed-countdown": "",
+
   "settings-requires-restart": "Требует перезапуска",
 
   "settings-option-keep-sidebar-open": "Держать сайдбар открытым",

--- a/src/_locales/sk.json
+++ b/src/_locales/sk.json
@@ -76,6 +76,11 @@
   "playback-label-im-feeling-lucky": "Cítim šťastie",
   "playback-label-toggle-repeat": "",
 
+  "player-load-failed-gpm": "",
+  "player-load-failed-ytm": "",
+  "player-load-failed-retry": "",
+  "player-load-failed-countdown": "",
+
   "settings-requires-restart": "Vyžaduje reštart",
 
   "settings-option-keep-sidebar-open": "Ponechať bočné menu otvorené",

--- a/src/_locales/sv.json
+++ b/src/_locales/sv.json
@@ -76,6 +76,11 @@
   "playback-label-im-feeling-lucky": "",
   "playback-label-toggle-repeat": "",
 
+  "player-load-failed-gpm": "",
+  "player-load-failed-ytm": "",
+  "player-load-failed-retry": "",
+  "player-load-failed-countdown": "",
+
   "settings-requires-restart": "Kräver omstart av GPMDP",
 
   "settings-option-keep-sidebar-open": "",

--- a/src/_locales/ua.json
+++ b/src/_locales/ua.json
@@ -76,6 +76,11 @@
   "playback-label-im-feeling-lucky": "",
   "playback-label-toggle-repeat": "Змінити режим повтору",
 
+  "player-load-failed-gpm": "",
+  "player-load-failed-ytm": "",
+  "player-load-failed-retry": "",
+  "player-load-failed-countdown": "",
+
   "settings-requires-restart": "Потребує перезапуску",
 
   "settings-option-keep-sidebar-open": "",

--- a/src/assets/less/main_window.less
+++ b/src/assets/less/main_window.less
@@ -1,6 +1,14 @@
 @import "_colors.less";
 @import "_variables.less";
 
+.fill-absolute() {
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 100%;
+  width: 100%;
+}
+
 .fill-parent {
   height: 100%;
   width: 100%;
@@ -335,12 +343,8 @@ html, body {
 }
 
 .offline-warning {
-  position: absolute;
+  .fill-absolute();
   background: @white;
-  top: 0;
-  left: 0;
-  height: 100%;
-  width: 100%;
   z-index: 999;
   text-align: center;
   display: none;
@@ -380,6 +384,29 @@ html, body {
   @media (max-width: 300px), (max-height: 350px) {
     i { font-size: 80px; }
     h1 { font-size: 22px; }
+  }
+}
+
+.load-failed {
+  .fill-absolute();
+  z-index: 999;
+
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+
+  text-align: center;
+
+  .reason {
+    opacity: 0.75;
+    margin: 10px 0;
+  }
+
+  .countdown {
+    opacity: 0.5;
+    margin-top: 10px;
+    font-size: smaller;
   }
 }
 

--- a/src/renderer/ui/components/generic/LoadError.js
+++ b/src/renderer/ui/components/generic/LoadError.js
@@ -1,0 +1,80 @@
+import { remote } from 'electron';
+import { RaisedButton } from 'material-ui';
+import React, { Component, PropTypes } from 'react';
+
+import { requireSettings } from './SettingsProvider';
+
+const RELOAD_INTERVAL = 15;
+
+class LoadError extends Component {
+  static propTypes = {
+    reason: PropTypes.string,
+    service: PropTypes.string.isRequired,
+  };
+
+  static defaultProps = {
+    reason: null,
+  }
+
+  constructor(...args) {
+    super(...args);
+    this.state = { countdown: RELOAD_INTERVAL };
+  }
+
+  componentWillReceiveProps(newProps) {
+    if (this.props.reason !== newProps.reason) {
+      // The `reason` property will change. If it now has a value,
+      // then start a timer to countdown the automatic reload.
+      // If it no longer has a value, then we can stop the timer.
+      if (newProps.reason) {
+        this.setState({ countdown: RELOAD_INTERVAL });
+        this.timer = setInterval(() => this._tick(), 1000);
+      } else {
+        clearInterval(this.timer);
+      }
+    }
+  }
+
+  _tick() {
+    // If the countdown will end, then reload automatically.
+    if (this.state.countdown === 1) {
+      this._reload();
+    } else {
+      this.setState((prev) => ({ countdown: prev.countdown - 1 }));
+    }
+  }
+
+  _reload() {
+    remote.getCurrentWindow().reload();
+  }
+
+  render() {
+    if (!this.props.reason) return null;
+
+    return (
+      <div className="load-failed" >
+        <div>
+          <div className="title">
+            {this.props.service === 'youtube-music' ? TranslationProvider.query('player-load-failed-ytm') : TranslationProvider.query('player-load-failed-gpm')}
+          </div>
+
+          <div className="reason">
+            {this.props.reason}
+          </div>
+
+          <RaisedButton
+            label={TranslationProvider.query('player-load-failed-retry')}
+            primary
+            onClick={this._reload}
+          />
+
+          <div className="countdown">
+            {TranslationProvider.query('player-load-failed-countdown').replace('$1', this.state.countdown)}
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
+
+export default requireSettings(LoadError, ['service'], {});

--- a/src/renderer/ui/components/generic/LoadError.js
+++ b/src/renderer/ui/components/generic/LoadError.js
@@ -6,6 +6,10 @@ import { requireSettings } from './SettingsProvider';
 
 const RELOAD_INTERVAL = 15;
 
+function reload() {
+  remote.getCurrentWindow().reload();
+}
+
 class LoadError extends Component {
   static propTypes = {
     reason: PropTypes.string,
@@ -38,14 +42,10 @@ class LoadError extends Component {
   _tick() {
     // If the countdown will end, then reload automatically.
     if (this.state.countdown === 1) {
-      this._reload();
+      reload();
     } else {
-      this.setState((prev) => ({ countdown: prev.countdown - 1 }));
+      this.setState(prev => ({ countdown: prev.countdown - 1 }));
     }
-  }
-
-  _reload() {
-    remote.getCurrentWindow().reload();
   }
 
   render() {
@@ -65,7 +65,7 @@ class LoadError extends Component {
           <RaisedButton
             label={TranslationProvider.query('player-load-failed-retry')}
             primary
-            onClick={this._reload}
+            onClick={reload}
           />
 
           <div className="countdown">

--- a/src/renderer/ui/pages/PlayerPage.js
+++ b/src/renderer/ui/pages/PlayerPage.js
@@ -19,34 +19,36 @@ import UpdateModal from '../components/modals/UpdateModal';
 import UninstallV2Modal from '../components/modals/UninstallV2Modal';
 import WelcomeNewVersionModal from '../components/modals/WelcomeNewVersionModal';
 
+function getTargetPage(settingsKey, defaultValue) {
+  return Settings.get('savePage', true) ? Settings.get(settingsKey, defaultValue) : defaultValue;
+}
+
 export default class PlayerPage extends Component {
   constructor(...args) {
     super(...args);
 
+    let webviewTarget;
+    let title;
+
     this.once = true;
-    const service = Settings.get('service');
     this.ready = false;
-    if (service === 'youtube-music') {
-      this.targetPage = Settings.get('savePage', true) ?
-        Settings.get('lastYTMPage', 'https://music.youtube.com/')
-        : 'https://music.youtube.com/';
-      this.state = {
-        loading: true,
-        webviewTarget: 'https://music.youtube.com/',
-        title: 'Youtube Music Desktop Player',
-        loadFailure: null,
-      };
-    } else if (service === 'google-play-music' || true) {
-      this.targetPage = Settings.get('savePage', true) ?
-        Settings.get('lastPage', 'https://play.google.com/music/listen')
-        : 'https://play.google.com/music/listen';
-      this.state = {
-        loading: true,
-        webviewTarget: 'https://play.google.com/music/listen#/wmp',
-        title: 'Google Play Music Desktop Player',
-        loadFailure: null,
-      };
+
+    if (Settings.get('service') === 'youtube-music') {
+      this.targetPage = getTargetPage('lastYTMPage', 'https://music.youtube.com/');
+      webviewTarget = 'https://music.youtube.com/';
+      title = 'Youtube Music Desktop Player';
+    } else {
+      this.targetPage = getTargetPage('lastPage', 'https://play.google.com/music/listen');
+      webviewTarget = 'https://play.google.com/music/listen#/wmp';
+      title = 'Google Play Music Desktop Player';
     }
+
+    this.state = {
+      loading: true,
+      webviewTarget,
+      title,
+      loadFailure: null,
+    };
   }
 
   componentDidMount() {
@@ -132,11 +134,10 @@ export default class PlayerPage extends Component {
   _savePage = (param) => {
     const url = param.url || param;
 
-    const service = Settings.get('service');
-    if (service === 'youtube-music') {
+    if (Settings.get('service') === 'youtube-music') {
       if (!/https?:\/\/music\.youtube\.com\//g.test(url)) return;
       Settings.set('lastYTMPage', url);
-    } else if (service === 'google-play-music' || true) {
+    } else {
       if (!/https?:\/\/play\.google\.com\/music/g.test(url)) return;
       Settings.set('lastPage', url);
     }

--- a/test/electron-renderer/ui/LoadError_spec.js
+++ b/test/electron-renderer/ui/LoadError_spec.js
@@ -1,0 +1,93 @@
+/* eslint-disable no-unused-expressions */
+
+import { remote } from 'electron';
+import React from 'react';
+import chai from 'chai';
+import { mount } from 'enzyme';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+
+import LoadError from '../../../build/renderer/ui/components/generic/LoadError';
+import materialUIContext from './_materialUIContext';
+import mockSettings from './_mockSettings';
+
+const expect = chai.use(sinonChai).expect;
+
+describe('<LoadError />', () => {
+  let sandbox;
+  let clock;
+  let window;
+
+  beforeEach(() => {
+    mockSettings();
+    sandbox = sinon.sandbox.create();
+    clock = sandbox.useFakeTimers();
+    window = { reload: sinon.spy() };
+    sandbox.stub(remote, 'getCurrentWindow').returns(window);
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('should render null when there is no failure reason', () => {
+    const component = mount(<LoadError reason={null} />, materialUIContext);
+    expect(component.children().length).to.equal(0);
+  });
+
+  it('should render the reason when a reason exists', () => {
+    const component = mount(<LoadError reason="Foo" />, materialUIContext);
+    expect(component.find('.reason').text()).to.equal('Foo');
+  });
+
+  it('should show a button to reload', () => {
+    const component = mount(<LoadError reason="Foo" />, materialUIContext);
+    const button = component.find('RaisedButton');
+    expect(button).to.have.lengthOf(1);
+    button.props().onClick();
+    expect(window.reload).to.have.been.calledOnce;
+  });
+
+  it('should reload automatically after 15 seconds', () => {
+    const component = mount(<LoadError />, materialUIContext);
+    component.setProps({ reason: 'Foo' });
+    clock.tick(14000);
+    expect(window.reload).to.have.not.been.called;
+    clock.tick(1000);
+    expect(window.reload).to.have.been.calledOnce;
+  });
+
+  it('should show the countdown for automatic reloading', () => {
+    global.TranslationProvider = {
+      query: () => 'foo $1 bar',
+    };
+
+    const component = mount(<LoadError />, materialUIContext);
+    const labels = [];
+
+    component.setProps({ reason: 'Foo' });
+
+    for (let i = 0; i < 15; i++) {
+      labels.push(component.find('.countdown').text());
+      clock.tick(1000);
+    }
+
+    expect(labels).to.deep.equal([
+      'foo 15 bar',
+      'foo 14 bar',
+      'foo 13 bar',
+      'foo 12 bar',
+      'foo 11 bar',
+      'foo 10 bar',
+      'foo 9 bar',
+      'foo 8 bar',
+      'foo 7 bar',
+      'foo 6 bar',
+      'foo 5 bar',
+      'foo 4 bar',
+      'foo 3 bar',
+      'foo 2 bar',
+      'foo 1 bar',
+    ]);
+  });
+});


### PR DESCRIPTION
Fixes #2769.

At startup, if the initial page of Google Play Music fails to load, instead of just showing a blank page, a "loading error" page is shown. This page has a button that allows you to reload the main window, causing the application to attempt to load Google Play Music again. The page will also automatically reload the main window after 15 seconds.

![image](https://user-images.githubusercontent.com/10321525/71541268-0bf0e980-29a2-11ea-9114-849c57e2cd78.png)
