### PR TITLE
Feature: Slack status for multiple workspaces

### DIFF
--- a/src/_locales/en-US.json
+++ b/src/_locales/en-US.json
@@ -135,7 +135,7 @@
   "settings-options-style-dialog-css-files": "CSS Files",
   "settings-options-style-dialog-all-files": "All Files",
 
-  "slack-token-label": "Enter your slack user token (can be found at $1)",
+  "slack-token-label": "Enter your Slack user token (can be found at $1). If you use multiple Slack workspaces, enter each token separated by a comma.",
   "slack-token-placeholder": "Slack token",
 
   "title-color-picker": "Color Picker",

--- a/src/_locales/en-US.json
+++ b/src/_locales/en-US.json
@@ -135,8 +135,8 @@
   "settings-options-style-dialog-css-files": "CSS Files",
   "settings-options-style-dialog-all-files": "All Files",
 
-  "slack-token-label": "Enter your Slack user tokens (can be found at $1).",
-  "slack-token-placeholder": "Slack tokens",
+  "slack-token-label": "Enter your Slack user tokens (can be found at $1)",
+  "slack-token-placeholder": "Slack token",
 
   "title-color-picker": "Color Picker",
   "title-settings": "Settings",

--- a/src/_locales/en-US.json
+++ b/src/_locales/en-US.json
@@ -135,8 +135,8 @@
   "settings-options-style-dialog-css-files": "CSS Files",
   "settings-options-style-dialog-all-files": "All Files",
 
-  "slack-token-label": "Enter your Slack user token (can be found at $1). If you use multiple Slack workspaces, enter each token separated by a comma.",
-  "slack-token-placeholder": "Slack token",
+  "slack-token-label": "Enter your Slack user tokens (can be found at $1).",
+  "slack-token-placeholder": "Slack tokens",
 
   "title-color-picker": "Color Picker",
   "title-settings": "Settings",

--- a/src/main/features/core/slack.js
+++ b/src/main/features/core/slack.js
@@ -39,16 +39,12 @@ function getProfileUpdate(title, artist, reset) {
 let clients;
 
 const getClients = () => {
-  if (!Settings.get('slackToken')) {
+  const tokens = Settings.get('slackToken');
+  if (!tokens || tokens.length === 0) {
     return null;
   }
 
-  clients = clients || Settings.get('slackToken')
-    .split(',')
-    .map(token => token.trim()) // Remove whitespace if ', ' is used as a separator
-    .filter(v => !!v) // Remove any empty tokens if the setting ends with ','
-    .map(token => new WebClient(token));
-
+  clients = clients || tokens.map(token => new WebClient(token.trim()));
   return clients;
 };
 

--- a/src/main/features/core/slack.js
+++ b/src/main/features/core/slack.js
@@ -51,7 +51,7 @@ const updateStatus = (reset = false) => {
   const profileUpdate = getProfileUpdate(title, artist, reset);
 
   // Create any uninitialized clients
-  Settings.get('slackToken').forEach(token => {
+  Settings.get('slackToken').forEach((token) => {
     if (!clients[token]) { clients[token] = new WebClient(token); }
   });
   Object.values(clients)
@@ -69,7 +69,7 @@ Settings.onChange('slackToken', () => {
   const oldTokens = Object.keys(clients);
 
   // Find any tokens that are being removed and reset their status
-  oldTokens.filter(v => !newTokens.includes(v)).forEach(v => {
+  oldTokens.filter(v => !newTokens.includes(v)).forEach((v) => {
     setClientProfile(clients[v], getStatusResetProfileUpdate());
     delete clients[v];
   });

--- a/src/renderer/ui/components/settings/TextListFieldSettings.js
+++ b/src/renderer/ui/components/settings/TextListFieldSettings.js
@@ -2,7 +2,7 @@ import React, { Component, PropTypes } from 'react';
 import muiThemeable from 'material-ui/styles/muiThemeable';
 import { List, ListItem } from 'material-ui/List';
 import TextField from 'material-ui/TextField';
-import FlatButton from 'material-ui/FlatButton';
+import RaisedButton from 'material-ui/RaisedButton';
 import { memoize } from 'lodash';
 
 import SettingsProvider from '../generic/SettingsProvider';
@@ -69,10 +69,12 @@ class TListField extends Component {
             key={value}
             primaryText={value}
             rightIconButton={
-              <FlatButton
-                label="Delete"
-                onClick={this.onRemove(i)}
-              />
+              <RaisedButton
+                onTouchTap={this.onRemove(i)}
+                primary
+              >
+                <i className="material-icons" style={{ verticalAlign: 'middle' }}>clear</i>
+              </RaisedButton>
             }
           />
         ))}
@@ -88,10 +90,12 @@ class TListField extends Component {
             />
           }
           rightIconButton={
-            <FlatButton
-              label="Add"
-              onClick={this.onAdd}
-            />
+            <RaisedButton
+              onTouchTap={this.onAdd}
+              primary
+            >
+              <i className="material-icons" style={{ verticalAlign: 'middle' }}>add</i>
+            </RaisedButton>
           }
         />
       </List>
@@ -109,6 +113,10 @@ export default class TextListFieldSettings extends Component {
     placeholder: PropTypes.string,
   };
 
+  static defaultProps = {
+    placeholder: '',
+  };
+
   render() {
     const textFieldProps = {
       label: this.props.label,
@@ -121,7 +129,12 @@ export default class TextListFieldSettings extends Component {
       keys.push(this.props.dependsOnSettingsKey);
     }
     return (
-      <SettingsProvider component={ThemedTListField} componentProps={textFieldProps} keys={keys} defaults={{}} />
+      <SettingsProvider
+        component={ThemedTListField}
+        componentProps={textFieldProps}
+        keys={keys}
+        defaults={{}}
+      />
     );
   }
 }

--- a/src/renderer/ui/components/settings/TextListFieldSettings.js
+++ b/src/renderer/ui/components/settings/TextListFieldSettings.js
@@ -1,0 +1,127 @@
+import React, { Component, PropTypes } from 'react';
+import muiThemeable from 'material-ui/styles/muiThemeable';
+import { List, ListItem } from 'material-ui/List';
+import TextField from 'material-ui/TextField';
+import FlatButton from 'material-ui/FlatButton';
+import { memoize } from 'lodash';
+
+import SettingsProvider from '../generic/SettingsProvider';
+
+class TListField extends Component {
+  static propTypes = {
+    label: PropTypes.string.isRequired,
+    settingsKey: PropTypes.string.isRequired,
+    setSetting: PropTypes.func.isRequired,
+    muiTheme: PropTypes.object,
+    dependsOnSettingsKey: PropTypes.string,
+    placeholder: PropTypes.string,
+  };
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      newValue: '',
+    };
+  }
+
+  onChange = (event, value) => {
+    this.setState({ newValue: value });
+  }
+
+  onAdd = () => {
+    if (this.state.newValue === '') { return; }
+
+    const currentValue = Settings.get(this.props.settingsKey, []);
+    if (!currentValue.includes(this.state.newValue)) {
+      this.props.setSetting(
+        this.props.settingsKey,
+        Settings.get(this.props.settingsKey, []).concat(this.state.newValue),
+      );
+    }
+
+    this.setState({ newValue: '' });
+  }
+
+  onRemove = memoize((index) => () => {
+    const currentValue = Settings.get(this.props.settingsKey, []);
+    Settings.set(
+      this.props.settingsKey,
+      currentValue.slice(0, index).concat(currentValue.slice(index + 1)),
+    );
+  });
+
+  render() {
+    const { dependsOnSettingsKey } = this.props;
+    if (dependsOnSettingsKey && !this.props[dependsOnSettingsKey]) {
+      return null;
+    }
+
+    const values = Settings.get(this.props.settingsKey, []);
+    if (typeof values === 'string') {
+      Settings.set(this.props.settingsKey, [values]);
+      return null;
+    }
+
+    return (
+      <List>
+        {values.map((value, i) => (
+          <ListItem
+            key={value}
+            primaryText={value}
+            rightIconButton={
+              <FlatButton
+                label="Delete"
+                onClick={this.onRemove(i)}
+              />
+            }
+          />
+        ))}
+        <ListItem
+          disabled
+          primaryText={
+            <TextField
+              id={`test-field-for-${this.props.settingsKey}`}
+              label={this.props.label}
+              value={this.state.newValue}
+              onChange={this.onChange}
+              placeholder={this.props.placeholder}
+            />
+          }
+          rightIconButton={
+            <FlatButton
+              label="Add"
+              onClick={this.onAdd}
+            />
+          }
+        />
+      </List>
+    );
+  }
+}
+
+const ThemedTListField = muiThemeable()(TListField);
+
+export default class TextListFieldSettings extends Component {
+  static propTypes = {
+    label: PropTypes.string.isRequired,
+    settingsKey: PropTypes.string.isRequired,
+    dependsOnSettingsKey: PropTypes.string,
+    placeholder: PropTypes.string,
+  };
+
+  render() {
+    const textFieldProps = {
+      label: this.props.label,
+      settingsKey: this.props.settingsKey,
+      dependsOnSettingsKey: this.props.dependsOnSettingsKey,
+      placeholder: this.props.placeholder,
+    };
+    const keys = [this.props.settingsKey];
+    if (this.props.dependsOnSettingsKey) {
+      keys.push(this.props.dependsOnSettingsKey);
+    }
+    return (
+      <SettingsProvider component={ThemedTListField} componentProps={textFieldProps} keys={keys} defaults={{}} />
+    );
+  }
+}

--- a/src/renderer/ui/components/settings/tabs/SlackTab.js
+++ b/src/renderer/ui/components/settings/tabs/SlackTab.js
@@ -1,4 +1,5 @@
 import React, { Component, PropTypes } from 'react';
+import muiThemeable from 'material-ui/styles/muiThemeable';
 
 import SettingsTabWrapper from './SettingsTabWrapper';
 import TextListFieldSettings from '../TextListFieldSettings';
@@ -7,6 +8,7 @@ import { requireSettings } from '../../generic/SettingsProvider';
 class SlackTab extends Component {
   static propTypes = {
     setSetting: PropTypes.func.isRequired,
+    muiTheme: PropTypes.object,
   };
 
   render() {
@@ -14,7 +16,13 @@ class SlackTab extends Component {
       <SettingsTabWrapper>
         <h4>
           {TranslationProvider.query('slack-token-label').replace('$1)', '')}
-          <a href="https://api.slack.com/custom-integrations/legacy-tokens" target="_blank" style={{ color: 'white' }}>https://api.slack.com/custom-integrations/legacy-tokens</a>)
+          <a
+            href="https://api.slack.com/custom-integrations/legacy-tokens"
+            target="_blank"
+            style={{ color: this.props.muiTheme.palette.primary1Color }}
+          >
+            https://api.slack.com/custom-integrations/legacy-tokens
+          </a>)
         </h4>
         <TextListFieldSettings
           label={TranslationProvider.query('slack-token-label')}
@@ -27,4 +35,5 @@ class SlackTab extends Component {
   }
 }
 
-export default requireSettings(SlackTab, ['slackToken'], { slackToken: '' });
+const ThemedSlackTab = muiThemeable()(SlackTab);
+export default requireSettings(ThemedSlackTab, ['slackToken'], { slackToken: '' });

--- a/src/renderer/ui/components/settings/tabs/SlackTab.js
+++ b/src/renderer/ui/components/settings/tabs/SlackTab.js
@@ -1,7 +1,7 @@
 import React, { Component, PropTypes } from 'react';
 
 import SettingsTabWrapper from './SettingsTabWrapper';
-import TextFieldSettings from '../TextFieldSettings';
+import TextListFieldSettings from '../TextListFieldSettings';
 import { requireSettings } from '../../generic/SettingsProvider';
 
 class SlackTab extends Component {
@@ -16,11 +16,12 @@ class SlackTab extends Component {
           {TranslationProvider.query('slack-token-label').replace('$1)', '')}
           <a href="https://api.slack.com/custom-integrations/legacy-tokens" target="_blank" style={{ color: 'white' }}>https://api.slack.com/custom-integrations/legacy-tokens</a>)
         </h4>
-        <TextFieldSettings
+        <TextListFieldSettings
           label={TranslationProvider.query('slack-token-label')}
           settingsKey={'slackToken'}
           placeholder={TranslationProvider.query('slack-token-placeholder')}
         />
+
       </SettingsTabWrapper>
     );
   }


### PR DESCRIPTION
This reworks the Slack status integration to support multiple tokens/workspaces, and adds a new settings field `TextListFieldSettings` that uses MaterialUI to render an array of strings as individual entries, with a text field for adding new values at the bottom. Adding a new token will update the status for all Slack clients, while removing a token will only reset the status for that token.
![2020-01-09T18:09:41-07:00](https://user-images.githubusercontent.com/90011/72117522-4eec7e80-330b-11ea-9e0a-5db1ce1a831d.png)
![2020-01-09T18:10:08-07:00](https://user-images.githubusercontent.com/90011/72117523-4eec7e80-330b-11ea-9d0a-dd40faf2840d.png)

