### PR TITLE
Fixes text spacing in ISSUE_TEMPLATE and moves to .github

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -8,7 +8,7 @@ Before you click that big tempting "Submit New Issue" button though, can you qui
 
 * [ ] I have checked that there are no issues with similar or the same content
 
-  **YOU SHOULD CHECK CLOSED ISSUES ASWELL**
+  **YOU SHOULD CHECK CLOSED ISSUES AS WELL**
 * [ ] I have checked the FAQ (https://github.com/MarshallOfSound/Google-Play-Music-Desktop-Player-UNOFFICIAL-/wiki/FAQ) and the answer I am looking for is not there
 * [ ] I have double checked and can reproduce the issue
 


### PR DESCRIPTION
Fixes text spacing for "AS WELL" and moves the template `.md` file to `.github` folder.