### PR TITLE
Fixed bug #3805

### DIFF
--- a/src/renderer/ui/components/generic/LyricsViewer.js
+++ b/src/renderer/ui/components/generic/LyricsViewer.js
@@ -84,6 +84,10 @@ class LyricsViewer extends Component {
       if (jumped) {
         lyricsP.stop();
         lyricsP.scrollTop(maxHeight * (Math.max(0, timeObj.current - actualWaitTime) / timeObj.total));
+
+        // Reset animate after jump to prevent unwanted scrolling
+        animate = Settings.get('scrollLyrics', true);
+        animationTimer.setTimeout();
       }
       animationTimer = setTimeout(() => {
         lyricsP.stop().animate({


### PR DESCRIPTION
Fixed bug #3805 which would cause lyrics to continue scrolling after reloading the lyrics screen. Fix allows for skipping to the correct place when loading lyrics, but disables further scrolling if lyric scrolling is disabled in desktop settings.