### PR TITLE
Add Button to open the Desktop Settings to YTM

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "gmusic-ui.js": "^2.2.5",
     "gmusic.js": "^6.1.5",
     "html-entities": "^1.2.0",
-    "jquery": "^2.2.4",
+    "jquery": "^3.5.0",
     "lastfm": "^0.9.2",
     "listenbrainz": "^1.0.4",
     "lodash": "^4.17.13",

--- a/src/renderer/windows/GPMWebView/interface/ytm/customUI.js
+++ b/src/renderer/windows/GPMWebView/interface/ytm/customUI.js
@@ -15,8 +15,25 @@ function installGPMButton() {
   document.querySelector('#right-content').prepend(elem);
 }
 
+function installSettingsButton() {
+  const elem = document.createElement('paper-icon-button');
+  elem.setAttribute('id', 'settings-button');
+  elem.setAttribute('class', 'yt-button-renderer');
+  elem.setAttribute('icon', 'settings');
+
+  elem.addEventListener('click', (e) => {
+    Emitter.fire('window:settings');
+    e.preventDefault();
+    e.stopPropagation();
+    return false;
+  });
+  // eslint-disable-next-line max-len
+  elem.innerHTML = '<iron-icon class="style-scope paper-icon-button"><svg xmlns="http://www.w3.org/2000/svg" enable-background="new 0 0 24 24" viewBox="0 0 24 24" fill="black" width="18px" height="18px"><g><path d="M0,0h24v24H0V0z" fill="none"/><path d="M19.14,12.94c0.04-0.3,0.06-0.61,0.06-0.94c0-0.32-0.02-0.64-0.07-0.94l2.03-1.58c0.18-0.14,0.23-0.41,0.12-0.61 l-1.92-3.32c-0.12-0.22-0.37-0.29-0.59-0.22l-2.39,0.96c-0.5-0.38-1.03-0.7-1.62-0.94L14.4,2.81c-0.04-0.24-0.24-0.41-0.48-0.41 h-3.84c-0.24,0-0.43,0.17-0.47,0.41L9.25,5.35C8.66,5.59,8.12,5.92,7.63,6.29L5.24,5.33c-0.22-0.08-0.47,0-0.59,0.22L2.74,8.87 C2.62,9.08,2.66,9.34,2.86,9.48l2.03,1.58C4.84,11.36,4.8,11.69,4.8,12s0.02,0.64,0.07,0.94l-2.03,1.58 c-0.18,0.14-0.23,0.41-0.12,0.61l1.92,3.32c0.12,0.22,0.37,0.29,0.59,0.22l2.39-0.96c0.5,0.38,1.03,0.7,1.62,0.94l0.36,2.54 c0.05,0.24,0.24,0.41,0.48,0.41h3.84c0.24,0,0.44-0.17,0.47-0.41l0.36-2.54c0.59-0.24,1.13-0.56,1.62-0.94l2.39,0.96 c0.22,0.08,0.47,0,0.59-0.22l1.92-3.32c0.12-0.22,0.07-0.47-0.12-0.61L19.14,12.94z M12,15.6c-1.98,0-3.6-1.62-3.6-3.6 s1.62-3.6,3.6-3.6s3.6,1.62,3.6,3.6S13.98,15.6,12,15.6z"/></g></svg></iron-icon>';
+  document.querySelector('#right-content').prepend(elem);
+}
 
 // Modify the GUI after everything is sufficiently loaded
 window.wait(() => {
+  installSettingsButton();
   installGPMButton();
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -4865,9 +4865,14 @@ jpeg-js@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/jpeg-js/-/jpeg-js-0.2.0.tgz#53e448ec9d263e683266467e9442d2c5a2ef5482"
 
-jquery@^2.1.4, jquery@^2.2.4:
+jquery@^2.1.4:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-2.2.4.tgz#2c89d6889b5eac522a7eea32c14521559c6cbf02"
+
+jquery@^3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.5.0.tgz#9980b97d9e4194611c36530e7dc46a58d7340fc9"
+  integrity sha512-Xb7SVYMvygPxbFMpTFQiHh1J7HClEaThguL15N/Gg37Lri/qKyhRGZYzHRyLH8Stq3Aow0LsHO2O2ci86fCrNQ==
 
 js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"


### PR DESCRIPTION
Added a Button to the Top App Bar of YTM to open the Desktop Settings.
![settins-button](https://user-images.githubusercontent.com/39559178/83772496-ba9d0280-a683-11ea-82c0-c86f30c345b1.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/marshallofsound/google-play-music-desktop-player-unofficial-/3850)
<!-- Reviewable:end -->
