### PR TITLE
Updates and Fixes issues with Discord Rich Presences

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,10 @@ No affiliation with Google. Google Play is a trademark of Google Inc.
 
 [1]: https://www.samuelattard.com
 
+
 Download
 ---------
-Head over to our website http://www.googleplaymusicdesktopplayer.com to download the latest release for your platform.
+Go to releases
 
 OS Support
 ------------

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@slack/client": "^4.8.0",
     "archiver": "^1.0.1",
     "auto-launch": "^4.0.0",
-    "discord-rich-presence": "^0.0.7",
+    "discord-rpc": "^3.1.0",
     "electron-chromecast": "^1.1.0",
     "gmusic-mini-player.js": "^2.0.11",
     "gmusic-theme.js": "^2.1.18",

--- a/src/main/features/core/discordRichPresence.js
+++ b/src/main/features/core/discordRichPresence.js
@@ -102,7 +102,7 @@ const tryConnecting = () => {
     Logger.info('[Discord RPC] Disconnected');
     client = null;
   });
-  client.login({ clientId: '380678077287628810' });
+  client.login({ clientId: '767047207425146880' });
 };
 
 app.on('before-quit', () => {


### PR DESCRIPTION
Possible fix to #2969
This issue was caused by a dead RPC connection when Discord wasn't open, still trying to send requests to it.

Fixes #3266
This is fixed by using my own Discord application instead of the currently used one. I've previously requested to join the Team for the existing one but haven't got a reply. I have this one setup for teams already, and willing to add people if I'm provided with a Discord username + Discrim.

Fixes #3404
A connect + disconnect event were needed to be able to check if the client was actually connected and when to check for reconnections for this.

Looking through the Basic Discord-rich-presneces library used before, there was no event triggered for disconnecting from client.
This is why I have instead replace it with the native discord-rpc library instead of the wrapper library originally used, for better control over the RPC + all of the events including the Disconnect.

I've also added an additional feature of showing a Heart icon on songs which are liked.